### PR TITLE
Reimplement pressure system effects on wind data, support multiple pressure systems

### DIFF
--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -60,26 +60,20 @@ export class MapView extends BaseComponent<IProps, IState> {
             url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
           />
           {
-            this.stores.simulation.highPressure &&
-            <Marker
-              position={this.stores.simulation.highPressure}
-              icon={highPressureIcon}
-              onDrag={this.handleHighPressureDrag}
-              draggable={true}
-            />
-            }
-          {
-            this.stores.simulation.lowPressure &&
-            <Marker
-              position={this.stores.simulation.lowPressure}
-              icon={lowPressureIcon}
-              onDrag={this.handleLowPressureDrag}
-              draggable={true}
-            />
+            this.stores.simulation.pressureSystems.map((ps, idx) =>
+              <Marker
+                key={idx}
+                position={ps.center}
+                icon={ps.type === "high" ? highPressureIcon : lowPressureIcon}
+                onDrag={this.handlePressureSysDrag.bind(this, idx)}
+                onDragEnd={this.handlePressureSysDragEnd.bind(this, idx)}
+                draggable={true}
+              />
+            )
           }
           {
             <Marker
-              position={this.stores.simulation.hurricanePos}
+              position={this.stores.simulation.hurricane.center}
               icon={hurricaneIcon}
             />
           }
@@ -106,11 +100,11 @@ export class MapView extends BaseComponent<IProps, IState> {
     }
   }
 
-  private handleHighPressureDrag = (e: Leaflet.LeafletMouseEvent) => {
-    this.stores.simulation.setHighPressure(e.latlng);
+  private handlePressureSysDrag = (idx: number, e: Leaflet.LeafletMouseEvent) => {
+    this.stores.simulation.setPressureSysCenter(idx, e.latlng);
   }
 
-  private handleLowPressureDrag = (e: Leaflet.LeafletMouseEvent) => {
-    this.stores.simulation.setLowPressure(e.latlng);
+  private handlePressureSysDragEnd = (idx: number) => {
+    this.stores.simulation.checkPressureSystem(idx);
   }
 }

--- a/src/math-utils.ts
+++ b/src/math-utils.ts
@@ -8,6 +8,8 @@ export interface ICoordinates {
   lng: number;
 }
 
+export interface IWindPoint extends IVector, ICoordinates {}
+
 const earthRadius = 6378000; // m
 
 export const latLngPlusVector = (p: ICoordinates, vec: IVector) => {
@@ -21,38 +23,19 @@ export const deg2rad = (deg: number) => {
   return deg * (Math.PI / 180);
 };
 
-export const angle = ({u, v}: IVector) => {
-  return Math.atan2(v, u);
-};
-
-export const length = ({u, v}: IVector) => {
-  return Math.sqrt(u * u + v * v);
-};
-
-export const rotate = ({u, v}: IVector, targetAngle: number) => {
-  const currentAngle = angle({u, v});
-  const angleDiff = targetAngle - currentAngle;
-  return {
-    u: Math.cos(angleDiff) * u - Math.sin(angleDiff) * v,
-    v: Math.sin(angleDiff) * u + Math.cos(angleDiff) * v
+export const vecAverage = (vectors: IVector[], weights: number[]) => {
+  const result = {
+    u: 0,
+    v: 0
   };
-};
-
-export const setLength = ({u, v}: IVector, targetLength: number) => {
-  const ratio = targetLength / length({u, v});
-  return {
-    u: u * ratio,
-    v: v * ratio
-  };
-};
-
-export const perpendicular = ({u, v}: IVector, clockwise = true) => {
-  return clockwise ? {u: v, v: -u} : {u: -v, v: u};
-};
-
-export const transform = (v1: IVector, v2: IVector, progress = 1) => {
-  return {
-    u: v1.u * (1 - progress) + v2.u * progress,
-    v: v1.v * (1 - progress) + v2.v * progress
-  };
+  let totalWeight = 0;
+  vectors.forEach((v, idx) => {
+    const w = weights[idx];
+    result.u += v.u * w;
+    result.v += v.v * w;
+    totalWeight += w;
+  });
+  result.u /= totalWeight;
+  result.v /= totalWeight;
+  return result;
 };

--- a/src/models/pressure-system.ts
+++ b/src/models/pressure-system.ts
@@ -1,0 +1,112 @@
+import { action, observable } from "mobx";
+import { kdTree } from "kd-tree-javascript";
+import {
+  ICoordinates, IVector, IWindPoint, latLngPlusVector, vecAverage
+} from "../math-utils";
+import {
+  headingTo, moveTo, distanceTo
+} from "geolocation-utils";
+
+type PressureSystemType = "high" | "low" | "hurricane";
+
+interface IPressureSystemOptions {
+  type: PressureSystemType;
+  center: ICoordinates;
+  strength?: number;
+  range?: number;
+  acceleration?: IVector;
+  speed?: IVector;
+}
+
+const pressureSystemRange = 2500000; // m
+const pressureSystemStrength = 1200000;
+const pressureSystemAngleOffsetDeg = 15; // deg
+// When wind is far enough from the center of the pressure system, pressure system effect is lower
+// and we start smoothing it out.
+const smoothPressureSystemRatio = 0.75;
+
+// Min distance between two pressure systems.
+const minPressureSystemDistance = 700000; // m
+
+// Ratio describing how hard is the global wind pushing hurricane.
+const globalWindToAcceleration = 70;
+// The bigger momentum, the longer hurricane will follow its own path, ignoring global wind.
+const pressureSysMomentum = 0.975;
+
+const minDistToOtherSystems = (sys: PressureSystem, otherSystems: PressureSystem[]) => {
+  const dists = otherSystems.map(ps => distanceTo(ps.center, sys.center));
+  let minDist = Infinity;
+  for (let i = 0; i < dists.length; i += 1) {
+    if (otherSystems[i] !== sys && dists[i] < minDist) {
+      minDist = dists[i];
+    }
+  }
+  return minDist;
+};
+
+export class PressureSystem {
+  @observable public type: PressureSystemType;
+  @observable public center: ICoordinates;
+  @observable public range = pressureSystemRange;
+  @observable public strength = pressureSystemStrength;
+
+  public speed = {u: 0, v: 0};
+
+  public lastCorrectCenter: ICoordinates;
+
+  constructor(props: IPressureSystemOptions) {
+    this.type = props.type;
+    this.center = props.center;
+    if (props.range !== undefined) {
+      this.range = props.range;
+    }
+    if (props.strength !== undefined) {
+      this.strength = props.strength;
+    }
+    if (props.speed !== undefined) {
+      this.speed = props.speed;
+    }
+  }
+
+  public applyToWindPoint = (wind: IWindPoint) => {
+    wind = Object.assign({}, wind);
+    const direction = this.type === "high" ? 1 : -1;
+    const heading = headingTo(this.center, wind) + 90 * direction - pressureSystemAngleOffsetDeg;
+    const distNormalized = distanceTo(this.center, wind) / this.range;
+    const exp = this.type === "high" ? 0.25 : 4;
+    const distExp = Math.pow(distNormalized, exp);
+    const length = this.type === "high" ? distExp * this.strength : (1 - distExp) * this.strength;
+    const prependVecEnd = moveTo(wind, {distance: length, heading});
+    let newWind = {u: prependVecEnd.lng - wind.lng, v: prependVecEnd.lat - wind.lat};
+    if (distNormalized > smoothPressureSystemRatio) {
+      const ratio = (distNormalized - smoothPressureSystemRatio) / (1 - smoothPressureSystemRatio);
+      newWind = vecAverage([wind, newWind], [ratio, 1 - ratio]);
+    }
+    wind.u = newWind.u;
+    wind.v = newWind.v;
+    return wind;
+  }
+
+  public move = (windSpeed: IVector, timestep: number) => {
+    // Simple Euler integration. Global wind speed is used to push / accelerate hurricane center.
+    this.speed.u *= pressureSysMomentum;
+    this.speed.v *= pressureSysMomentum;
+    this.speed.u += windSpeed.u * globalWindToAcceleration * timestep;
+    this.speed.v += windSpeed.v * globalWindToAcceleration * timestep;
+    const posDiff = {u: this.speed.u * timestep, v: this.speed.v * timestep};
+    this.center = latLngPlusVector(this.center, posDiff);
+  }
+
+  @action.bound public setCenter(center: ICoordinates, pressureSystems: PressureSystem[]) {
+    if (minDistToOtherSystems(this, pressureSystems) >= minPressureSystemDistance) {
+      this.lastCorrectCenter = center;
+    }
+    this.center = center;
+  }
+
+  @action.bound public checkPressureSystem(pressureSystems: PressureSystem[]) {
+    if (this.lastCorrectCenter && minDistToOtherSystems(this, pressureSystems) <= minPressureSystemDistance) {
+      this.center = this.lastCorrectCenter;
+    }
+  }
+}

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -1,12 +1,13 @@
 import { LatLngExpression, Point, Map} from "leaflet";
 import {action, observable, computed} from "mobx";
+import { PressureSystem } from "./pressure-system";
 import * as decWind from "../../wind-data-json/dec-simple.json";
 import * as marchWind from "../../wind-data-json/mar-simple.json";
 import * as juneWind from "../../wind-data-json/jun-simple.json";
 import * as septWind from "../../wind-data-json/sep-simple.json";
 import { kdTree } from "kd-tree-javascript";
 import {
-  ICoordinates, IVector, rotate, length, transform, angle, setLength, perpendicular, latLngPlusVector
+  ICoordinates, IWindPoint, vecAverage
 } from "../math-utils";
 import {
   headingTo, moveTo, distanceTo
@@ -15,8 +16,6 @@ import {
 import config from "../config";
 
 type Season = "winter" | "spring" | "summer" | "fall";
-
-interface IWindPoint extends IVector, ICoordinates {}
 
 interface IWindDataset {
   winter: IWindPoint[];
@@ -32,24 +31,13 @@ const windData: IWindDataset = {
   fall: septWind.windVectors
 };
 
-const pressureSystemRange = 3000000; // m
-const pressureSystemStrength = 10;
-const pressureSystemAngleOffset = 0.3; // radians
-
-const hurricaneRange = 1200000; // m
-const hurricaneStrength = 30;
+const hurricaneRange = 1000000; // m
+const hurricaneStrength = 2700000;
 
 const timestep = 1;
-// Ratio describing how hard is the global wind pushing hurricane.
-const globalWindToHurricaneAcceleration = 70;
-// The bigger momentum, the longer hurricane will follow its own path, ignoring global wind.
-const hurricaneMomentum = 0.96;
 
 const initialHurricanePosition = {lat: 15, lng: -20};
-const initialHurricaneSpeed = {u: 0, v: 0};
-const initialHurricaneAcceleration = {u: 0, v: 0};
-
-const minPressureSystemDistance = 700000; // m
+const initialHurricaneSpeed = {u: -20000, v: 0};
 
 export class SimulationModel {
   // Region boundaries.
@@ -63,12 +51,33 @@ export class SimulationModel {
   @observable public season: Season = config.season;
 
   // Pressure systems affect winds.
-  @observable public highPressure: ICoordinates = {lat: 30, lng: -28};
-  @observable public lowPressure: ICoordinates = {lat: 38, lng: -80};
+  @observable public pressureSystems: PressureSystem[] = [
+    new PressureSystem({
+      type: "high",
+      center: {lat: 30, lng: -28}
+    }),
+    new PressureSystem({
+      type: "high",
+      center: {lat: 35, lng: -5}
+    }),
+    new PressureSystem({
+      type: "low",
+      center: {lat: 38, lng: -80}
+    }),
+    new PressureSystem({
+      type: "low",
+      center: {lat: 48, lng: -95}
+    })
+  ];
 
-  @observable public hurricanePos: ICoordinates = initialHurricanePosition;
-  @observable public hurricaneSpeed: IVector = initialHurricaneSpeed;
-  @observable public hurricaneAcceleration: IVector = initialHurricaneAcceleration;
+  @observable public hurricane: PressureSystem = new PressureSystem({
+    type: "hurricane",
+    center: initialHurricanePosition,
+    range: hurricaneRange,
+    strength: hurricaneStrength,
+    speed: initialHurricaneSpeed
+  });
+
   @observable public simulationStarted = false;
 
   @observable public latLngToContainerPoint: (arg: LatLngExpression) => Point = () => new Point(0, 0);
@@ -80,38 +89,21 @@ export class SimulationModel {
   @computed get wind() {
     const result: IWindPoint[] = [];
     this.baseWind.forEach(w => {
-      const newWind = Object.assign({}, w);
-      const distFromHighP = distanceTo(this.highPressure, w);
-      const distFromLowP = distanceTo(this.lowPressure, w);
-      let lowPWindMod = {u: 0, v: 0};
-      let highPWindMod = {u: 0, v: 0};
-      if (distFromLowP < pressureSystemRange) {
-        const perpendVec = perpendicular({u: w.lng - this.lowPressure.lng, v: w.lat - this.lowPressure.lat}, false);
-        const targetLength = (1 - distFromLowP / pressureSystemRange) * pressureSystemStrength;
-        const targetWind = setLength(rotate(w, angle(perpendVec) + pressureSystemAngleOffset), targetLength);
-        lowPWindMod = transform(w, targetWind, 1 - Math.pow(distFromLowP / pressureSystemRange, 4));
+      const pressureSysWinds: IWindPoint[] = [];
+      const pressureSysWeights: number[] = [];
+      this.pressureSystems.forEach(ps => {
+        const dist = distanceTo(ps.center, w);
+        if (dist < ps.range) {
+          pressureSysWinds.push(ps.applyToWindPoint(w));
+          pressureSysWeights.push(1 - dist / ps.range);
+        }
+      });
+      if (pressureSysWinds.length > 0) {
+        const newWind = vecAverage(pressureSysWinds, pressureSysWeights);
+        result.push(Object.assign({}, w, newWind));
+      } else {
+        result.push(w);
       }
-      if (distFromHighP && distFromHighP < pressureSystemRange) {
-        const perpendVec = perpendicular({u: w.lng - this.highPressure.lng, v: w.lat - this.highPressure.lat}, true);
-        const targetLength = distFromHighP / pressureSystemRange * pressureSystemStrength;
-        const targetWind = setLength(rotate(w, angle(perpendVec) + pressureSystemAngleOffset), targetLength);
-        highPWindMod = transform(w, targetWind, 1 - Math.pow(distFromHighP / pressureSystemRange, 4));
-      }
-      let pressureAffectedWind = {u: 0, v: 0};
-      if (length(highPWindMod) && length(lowPWindMod)) {
-        const hf = distFromHighP / pressureSystemRange;
-        const lf = distFromLowP / pressureSystemRange;
-        pressureAffectedWind = transform(highPWindMod, lowPWindMod, hf / (hf + lf));
-      } else if (length(highPWindMod)) {
-        pressureAffectedWind = highPWindMod;
-      } else if (length(lowPWindMod)) {
-        pressureAffectedWind = lowPWindMod;
-      }
-      if (length(pressureAffectedWind) > 0) {
-        newWind.u = pressureAffectedWind.u;
-        newWind.v = pressureAffectedWind.v;
-      }
-      result.push(newWind);
     });
     return result;
   }
@@ -131,17 +123,12 @@ export class SimulationModel {
   @computed get windIncHurricane() {
     const result: IWindPoint[] = [];
     this.windIncBounds.forEach(w => {
-      const newWind = Object.assign({}, w);
-      const distFromHurricane = distanceTo(this.hurricanePos, w);
-      if (distFromHurricane < hurricaneRange) {
-        const perpendVec = perpendicular({u: w.lng - this.hurricanePos.lng, v: w.lat - this.hurricanePos.lat}, false);
-        const targetLength = (1 - distFromHurricane / hurricaneRange) * hurricaneStrength;
-        const targetWind = setLength(rotate(w, angle(perpendVec) + pressureSystemAngleOffset), targetLength);
-        const hurricaneMod = transform(w, targetWind, 1 - Math.pow(distFromHurricane / hurricaneRange, 4));
-        newWind.u = hurricaneMod.u;
-        newWind.v = hurricaneMod.v;
+      const dist = distanceTo(this.hurricane.center, w);
+      if (dist < this.hurricane.range) {
+        result.push(this.hurricane.applyToWindPoint(w));
+      } else {
+        result.push(w);
       }
-      result.push(newWind);
     });
     return result;
   }
@@ -157,33 +144,17 @@ export class SimulationModel {
     this.latLngToContainerPoint = map.latLngToContainerPoint.bind(map);
   }
 
-  @action.bound public setHighPressure(center: ICoordinates) {
-    if (this.lowPressure && distanceTo(center, this.lowPressure) > minPressureSystemDistance) {
-      this.highPressure = center;
-    } else {
-      const heading = headingTo(this.lowPressure, center);
-      this.highPressure = moveTo(this.lowPressure, { heading, distance: minPressureSystemDistance * 1.1 });
-    }
+  @action.bound public setPressureSysCenter(idx: number, center: ICoordinates) {
+    this.pressureSystems[idx].setCenter(center, this.pressureSystems);
   }
 
-  @action.bound public setLowPressure(center: ICoordinates) {
-    if (this.highPressure && distanceTo(center, this.highPressure) > minPressureSystemDistance) {
-      this.lowPressure = center;
-    } else {
-      const heading = headingTo(this.highPressure, center);
-      this.lowPressure = moveTo(this.highPressure, { heading, distance: minPressureSystemDistance * 1.1 });
-    }
+  @action.bound public checkPressureSystem(idx: number) {
+    this.pressureSystems[idx].checkPressureSystem(this.pressureSystems);
   }
 
   @action.bound public tick() {
-    // Simple Euler integration. Global wind speed is used to push / accelerate hurricane center.
-    const windSpeed = this.windAt(this.hurricanePos);
-    this.hurricaneSpeed.u *= hurricaneMomentum;
-    this.hurricaneSpeed.v *= hurricaneMomentum;
-    this.hurricaneSpeed.u += windSpeed.u * globalWindToHurricaneAcceleration * timestep;
-    this.hurricaneSpeed.v += windSpeed.v * globalWindToHurricaneAcceleration * timestep;
-    const posDiff = {u: this.hurricaneSpeed.u * timestep, v: this.hurricaneSpeed.v * timestep};
-    this.hurricanePos = latLngPlusVector(this.hurricanePos, posDiff);
+    const windSpeed = this.windAt(this.hurricane.center);
+    this.hurricane.move(windSpeed, timestep);
     if (this.simulationStarted) {
       requestAnimationFrame(this.tick);
     }
@@ -200,9 +171,8 @@ export class SimulationModel {
 
   @action.bound public reset() {
     this.simulationStarted = false;
-    this.hurricanePos = initialHurricanePosition;
-    this.hurricaneSpeed = initialHurricaneSpeed;
-    this.hurricaneAcceleration = initialHurricaneAcceleration;
+    this.hurricane.center = initialHurricanePosition;
+    this.hurricane.speed = initialHurricaneSpeed;
   }
 
   public windAt(point: ICoordinates) {


### PR DESCRIPTION
[#163098140]

Demo:
http://hurricane.concord.org/branch/new-math/index.html?navigation=true
You can compare that with old math:
http://hurricane.concord.org/version/0.0.1/index.html?navigation=true

I've reimplemented and refactored most of the code responsible for pressure system calculations. Now, it can support any number of pressure systems, their shape should be better, no sharp edges, and systems next to each other should interact better. Hopefully, the code is cleaner and simpler now too.

New version:
<img width="547" alt="new" src="https://user-images.githubusercontent.com/767857/51188316-0360e980-18de-11e9-93f2-840e354cedcf.png">
Old version:
<img width="527" alt="old" src="https://user-images.githubusercontent.com/767857/51188328-08259d80-18de-11e9-8b7f-8ad9db5abdee.png">
