### PR TITLE
Add more tests

### DIFF
--- a/cypress/integration/pressure-system.test.ts
+++ b/cypress/integration/pressure-system.test.ts
@@ -1,0 +1,24 @@
+context("Pressure System", () => {
+  beforeEach(() => {
+    cy.visit("");
+    cy.window().then((win: any) => {
+      // Limit number of pressure systems to 1.
+      win.simulation.pressureSystems.length = 1;
+    })
+  });
+
+  it("can have strength adjusted by slider", () => {
+    cy.window().then((win: any) => {
+      const oldStrength = win.simulation.pressureSystems[0].strength;
+      cy.get("div[role='slider'] button").first()
+        .trigger('mousedown', { which: 1 });
+      cy.get(".leaflet-container")
+        // move slider up
+        .trigger('mousemove', { pageY: 0, clientY: 0 })
+        .trigger('mouseup', { force: true })
+        .then(() => {
+          expect(win.simulation.pressureSystems[0].strength).to.not.eql(oldStrength);
+        });
+    });
+  });
+});

--- a/src/components/pressure-system-marker.test.tsx
+++ b/src/components/pressure-system-marker.test.tsx
@@ -34,7 +34,11 @@ describe("PressureSystemMarker component", () => {
       </Provider>
     );
     const marker = (wrapper.find(PressureSystemMarker).instance() as any).wrappedInstance as PressureSystemMarker;
-    marker.handlePressureSysDrag({latlng: {lat: 1, lng: 2} as LatLng} as LeafletMouseEvent);
-    expect(model.center).toEqual({lat: 1, lng: 2});
+    marker.handlePressureSysDrag({latlng: {lat: 20, lng: 30} as LatLng} as LeafletMouseEvent);
+    expect(model.center).toEqual({lat: 20, lng: 30});
+
+    marker.handlePressureSysDrag({latlng: {lat: 0, lng: 30} as LatLng} as LeafletMouseEvent);
+    // Limit lat to 10, don't let users drag the pressure system to southern hemisphere.
+    expect(model.center).toEqual({lat: 10, lng: 30});
   });
 });

--- a/src/models/pressure-system.ts
+++ b/src/models/pressure-system.ts
@@ -9,7 +9,7 @@ import config from "../config";
 
 export type PressureSystemType = "high" | "low" | "hurricane";
 
-interface IPressureSystemOptions {
+export interface IPressureSystemOptions {
   type: PressureSystemType;
   center: ICoordinates;
   strength?: number;
@@ -17,6 +17,9 @@ interface IPressureSystemOptions {
   acceleration?: IVector;
   speed?: IVector;
 }
+
+// Limit pressure systems only to the northern hemisphere.
+const minLat = 10;
 
 const minDistToOtherSystems = (sys: PressureSystem, otherSystems: PressureSystem[]) => {
   const dists = otherSystems.map(ps => distanceTo(ps.center, sys.center));
@@ -88,6 +91,7 @@ export class PressureSystem {
   }
 
   @action.bound public setCenter(center: ICoordinates, pressureSystems: PressureSystem[]) {
+    center.lat = Math.max(minLat, center.lat);
     if (minDistToOtherSystems(this, pressureSystems) >= config.minPressureSystemDistance) {
       this.lastCorrectCenter = center;
     }

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -1,0 +1,228 @@
+import { SimulationModel, ISimulationOptions, windData, sstImages } from "./simulation";
+import config from "../config";
+const fs = require("fs");
+
+const options: ISimulationOptions = {
+  // Ensure that the initial season is always the same.
+  season: "fall",
+  pressureSystems: []
+};
+
+// File mock returns just a single value by default. Set different file names so some tests can work fine.
+sstImages.fall = "fall.png";
+sstImages.summer = "summer.png";
+
+// Set some fake wind data that is easy to test.
+const fallWind = [
+  {lat: 10, lng: -10, u: 10, v: -10},
+  {lat: 10, lng: 10, u: 10, v: 10}
+];
+windData.fall = fallWind;
+
+describe("SimulationModel store", () => {
+  beforeEach(() => {
+    global.fetch.resetMocks();
+    // SST Image data.
+    global.fetch.mockResponse("123");
+  });
+
+  it("can be created without errors", () => {
+    const sim = new SimulationModel(options);
+    expect(sim.hurricane).toBeDefined();
+  });
+
+  describe("wind data", () => {
+    it("returns correct, averaged wind when there are no pressure systems", () => {
+      const sim = new SimulationModel(options);
+      expect(sim.baseWind.length).toEqual(2);
+      expect(sim.wind).toEqual(fallWind);
+      expect(sim.windAt({lat: 10, lng: -10})).toEqual({u: 10, v: -10});
+      expect(sim.windAt({lat: 10, lng: 10})).toEqual({u: 10, v: 10});
+      expect(sim.windAt({lat: 10, lng: 0})).toEqual({u: 10, v: 0});
+      // avg
+      expect(sim.windAt({lat: 10, lng: -5}).u).toBeCloseTo(10);
+      expect(sim.windAt({lat: 10, lng: -5}).v).toBeCloseTo(-5);
+      expect(sim.windAt({lat: 10, lng: -9}).u).toBeCloseTo(10);
+      expect(sim.windAt({lat: 10, lng: -9}).v).toBeCloseTo(-9);
+      expect(sim.windAt({lat: 10, lng: 5}).u).toBeCloseTo(10);
+      expect(sim.windAt({lat: 10, lng: 5}).v).toBeCloseTo(5);
+      expect(sim.windAt({lat: 10, lng: 9}).u).toBeCloseTo(10);
+      expect(sim.windAt({lat: 10, lng: 9}).v).toBeCloseTo(9);
+    });
+
+    it("takes pressure systems into account", () => {
+      // High pressure system.
+      let sim = new SimulationModel({
+        season: "fall",
+        pressureSystems: [
+          {
+            type: "high",
+            center: {lat: 10, lng: 0},
+            strength: 1500000
+          }
+        ]
+      });
+      expect(sim.baseWind.length).toEqual(2);
+      expect(sim.wind).not.toEqual(fallWind);
+      // Vector pointing up and slightly outwards.
+      let p = sim.windAt({lat: 10, lng: -10});
+      expect(p.u).toBeLessThan(1);
+      expect(p.u).toBeGreaterThan(-2);
+      expect(p.v).toBeGreaterThan(10);
+      expect(p.v).toBeLessThan(11);
+      // Vector pointing down and slightly outwards.
+      p = sim.windAt({lat: 10, lng: 10});
+      expect(p.u).toBeGreaterThan(1);
+      expect(p.u).toBeLessThan(2);
+      expect(p.v).toBeLessThan(-10);
+      expect(p.v).toBeGreaterThan(-11);
+
+      // Low pressure system.
+      sim = new SimulationModel({
+        season: "fall",
+        pressureSystems: [
+          {
+            type: "low",
+            center: {lat: 10, lng: 0},
+            strength: 1500000
+          }
+        ]
+      });
+      expect(sim.baseWind.length).toEqual(2);
+      expect(sim.wind).not.toEqual(fallWind);
+      // Vector pointing down and slightly inwards.
+      p = sim.windAt({lat: 10, lng: -10});
+      expect(p.u).toBeGreaterThan(4);
+      expect(p.u).toBeLessThan(5);
+      expect(p.v).toBeLessThan(-12);
+      expect(p.v).toBeGreaterThan(-13);
+      // Vector pointing up and slightly inwards.
+      p = sim.windAt({lat: 10, lng: 10});
+      expect(p.u).toBeLessThan(-4);
+      expect(p.u).toBeGreaterThan(-5);
+      expect(p.v).toBeGreaterThan(12);
+      expect(p.v).toBeLessThan(13);
+    });
+
+    describe("windIncHurricane", () => {
+      it("includes hurricane effect", () => {
+        const sim = new SimulationModel(options);
+        sim.hurricane.center = {lat: 10, lng: 0};
+        // Make it super strong so it affects two wind points that we have.
+        sim.hurricane.strength = 10000000;
+        expect(sim.windIncHurricane.length).toEqual(2);
+        expect(sim.windIncHurricane).not.toEqual(fallWind);
+        // Vector pointing down and slightly inwards.
+        let p = sim.windIncHurricane[0];
+        expect(p.u).toBeGreaterThan(29);
+        expect(p.u).toBeLessThan(30);
+        expect(p.v).toBeLessThan(-84);
+        expect(p.v).toBeGreaterThan(-85);
+        // Vector pointing up and slightly inwards.
+        p = sim.windIncHurricane[1];
+        expect(p.u).toBeLessThan(-32);
+        expect(p.u).toBeGreaterThan(-33);
+        expect(p.v).toBeGreaterThan(83);
+        expect(p.v).toBeLessThan(84);
+      });
+    });
+  });
+
+  describe("sea surface temperature data", () => {
+    it("downloads sea surface temperature data on init or change of the season", () => {
+      const sim = new SimulationModel(options);
+      expect(sim.seaSurfaceTempImgUrl).toEqual("fall.png");
+      expect(sim.seaSurfaceTempData).toEqual(null); // no time to parse it
+      expect(global.fetch.mock.calls.length).toEqual(1);
+      expect(global.fetch.mock.calls[0][0]).toEqual(sim.seaSurfaceTempImgUrl);
+
+      sim.season = "summer";
+      expect(sim.seaSurfaceTempImgUrl).toEqual("summer.png");
+      expect(sim.seaSurfaceTempData).toEqual(null); // no time to parse it
+      expect(global.fetch.mock.calls.length).toEqual(2);
+      expect(global.fetch.mock.calls[1][0]).toEqual(sim.seaSurfaceTempImgUrl);
+      // No valid data parsed yet, so expect null.
+      expect(sim.seaSurfaceTempAt(config.initialHurricanePosition)).toEqual(null);
+    });
+
+    it("reports correct SST value", (done) => {
+      global.fetch.mockResponseOnce(fs.readFileSync("./sea-surface-temp-img/sep.png"));
+      const sim = new SimulationModel(options);
+      sim._seaSurfaceTempDataParsed = () => {
+        expect(sim.seaSurfaceTempData).not.toEqual(null); // real data, should be already parsed
+        // Temperature in September at lat 20 lng -20 is 24.02*C.
+        // Can be checked here:
+        // https://worldview.earthdata.nasa.gov/?p=geographic&l=MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly,Reference_Labels(hidden),Reference_Features,Coastlines(hidden)&t=2018-09-19-T00%3A00%3A00Z&z=3&v=-144.11630581918422,-22.21990140009921,35.883694180815795,68.41291109990078
+        // or in our data sets.
+        expect(sim.seaSurfaceTempAt({lat: 20, lng: -20})).toEqual(24.02);
+        expect(sim.seaSurfaceTempAt({lat: 20, lng: -90})).toEqual(null); // land
+
+        // Change season and test again.
+        global.fetch.mockResponseOnce(fs.readFileSync("./sea-surface-temp-img/jun.png"));
+        sim.season = "summer";
+        sim._seaSurfaceTempDataParsed = () => {
+          expect(sim.seaSurfaceTempData).not.toEqual(null); // real data, should be already parsed
+          // Temperature in June at lat 20 lng -20 is 20.73*C (colder than in Sept).
+          // Can be checked here:
+          // https://worldview.earthdata.nasa.gov/?p=geographic&l=MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly,Reference_Labels(hidden),Reference_Features,Coastlines(hidden)&t=2018-09-19-T00%3A00%3A00Z&z=3&v=-144.11630581918422,-22.21990140009921,35.883694180815795,68.41291109990078
+          // or in our data sets.
+          expect(sim.seaSurfaceTempAt({lat: 20, lng: -20})).toEqual(20.73);
+          expect(sim.seaSurfaceTempAt({lat: 20, lng: -90})).toEqual(null); // land
+          done();
+        };
+      };
+    // 10s timeout, parsing can take some time.
+    });
+  });
+
+  describe("tick", () => {
+    it("increases simulation time, moves hurricane and saves it track", () => {
+      const sim = new SimulationModel(options);
+      sim.hurricane.move = jest.fn();
+      sim.seaSurfaceTempAt = jest.fn();
+      expect(sim.time).toEqual(0);
+      expect(sim.hurricaneTrack.length).toEqual(0);
+      const oldPos = sim.hurricane.center;
+      sim.tick();
+      expect(sim.time).toBeGreaterThan(0);
+      expect(sim.hurricane.move).toHaveBeenCalled();
+      expect(sim.seaSurfaceTempAt).toHaveBeenCalled();
+      expect(sim.hurricaneTrack.length).toBeGreaterThan(0);
+      expect(sim.hurricaneTrack[0].strength).toEqual(sim.hurricane.strength);
+      expect(sim.hurricaneTrack[0].position).toEqual(oldPos);
+    });
+  });
+
+  describe("reset", () => {
+    it("restores initial settings", () => {
+      const sim = new SimulationModel(options);
+      sim.time = 123;
+      sim.hurricane.center = {lat: 33, lng: 123};
+      sim.hurricane.speed = {u: 123, v: 123};
+      sim.hurricaneTrack = [{strength: 123, position: {lat: 33, lng: 123}}];
+      sim.reset();
+      expect(sim.time).toEqual(0);
+      expect(sim.hurricane.center).toEqual(config.initialHurricanePosition);
+      expect(sim.hurricane.speed).toEqual(config.initialHurricaneSpeed);
+      expect(sim.hurricaneTrack.length).toEqual(0);
+    });
+  });
+
+  describe("start", () => {
+    it("starts the simulation", () => {
+      const sim = new SimulationModel(options);
+      expect(sim.simulationStarted).toEqual(false);
+      sim.start();
+      expect(sim.simulationStarted).toEqual(true);
+    });
+  });
+
+  describe("stop", () => {
+    it("stops the simulation", () => {
+      const sim = new SimulationModel(options);
+      sim.simulationStarted = true;
+      sim.stop();
+      expect(sim.simulationStarted).toEqual(false);
+    });
+  });
+});

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -152,7 +152,9 @@ describe("SimulationModel store", () => {
         expect(sim.seaSurfaceTempData).not.toEqual(null); // real data, should be already parsed
         // Temperature in September at lat 20 lng -20 is 24.02*C.
         // Can be checked here:
-        // https://worldview.earthdata.nasa.gov/?p=geographic&l=MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly,Reference_Labels(hidden),Reference_Features,Coastlines(hidden)&t=2018-09-19-T00%3A00%3A00Z&z=3&v=-144.11630581918422,-22.21990140009921,35.883694180815795,68.41291109990078
+        // https://worldview.earthdata.nasa.gov/?p=geographic&l=MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly,Reference_Lab
+        // els(hidden),Reference_Features,Coastlines(hidden)&t=2018-09-19-T00%3A00%3A00Z&z=3&v=-144.11630581918422,-22.
+        // 21990140009921,35.883694180815795,68.41291109990078
         // or in our data sets.
         expect(sim.seaSurfaceTempAt({lat: 20, lng: -20})).toEqual(24.02);
         expect(sim.seaSurfaceTempAt({lat: 20, lng: -90})).toEqual(null); // land
@@ -164,7 +166,9 @@ describe("SimulationModel store", () => {
           expect(sim.seaSurfaceTempData).not.toEqual(null); // real data, should be already parsed
           // Temperature in June at lat 20 lng -20 is 20.73*C (colder than in Sept).
           // Can be checked here:
-          // https://worldview.earthdata.nasa.gov/?p=geographic&l=MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly,Reference_Labels(hidden),Reference_Features,Coastlines(hidden)&t=2018-09-19-T00%3A00%3A00Z&z=3&v=-144.11630581918422,-22.21990140009921,35.883694180815795,68.41291109990078
+          // https://worldview.earthdata.nasa.gov/?p=geographic&l=MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly,Reference_
+          // Labels(hidden),Reference_Features,Coastlines(hidden)&t=2018-09-19-T00%3A00%3A00Z&z=3&v=-144.11630581918422,
+          // -22.21990140009921,35.883694180815795,68.41291109990078
           // or in our data sets.
           expect(sim.seaSurfaceTempAt({lat: 20, lng: -20})).toEqual(20.73);
           expect(sim.seaSurfaceTempAt({lat: 20, lng: -90})).toEqual(null); // land


### PR DESCRIPTION
This PR mostly adds `Simulation` helper (engine) tests. I think this part of the app is well tested now, and it was possible to test crucial parts of this class (wind averaging, sea surface temp reading from PNG, etc.).
Also, I've added new Cypress test.

Current coverage:
<img width="666" alt="screenshot 2019-01-25 at 22 23 16" src="https://user-images.githubusercontent.com/767857/51765040-28303a80-20f0-11e9-9cad-251719e503e7.png">
