### PR TITLE
Increase number of wind arrows visible when user zooms in

### DIFF
--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -48,7 +48,7 @@ export class MapView extends BaseComponent<IProps, IState> {
           // Also, apply small padding (3%) as it feels better and otherwise Leaflet is triggering another animations.
           const maxBounds = map.getBounds().pad(0.03);
           const minZoom = map.getZoom();
-          map.setMinZoom(minZoom);
+          // map.setMinZoom(minZoom);
           map.setMaxBounds(maxBounds);
           this._programmaticMapUpdate = false;
         });
@@ -75,7 +75,7 @@ export class MapView extends BaseComponent<IProps, IState> {
              style={{width: "100%", height: "100%"}}
              zoomControl={false}
              onViewportChanged={this.handleViewportChanged}
-             zoom={5}
+             zoom={4}
              center={[30, -45]}
         >
           { navigation && <ZoomControl position="topleft"/> }

--- a/src/components/pixi-wind-layer.test.tsx
+++ b/src/components/pixi-wind-layer.test.tsx
@@ -37,32 +37,32 @@ describe("PixiWindLayer component", () => {
 
     const windLayer = (wrapper.find(PixiWindLayer).instance() as any).wrappedInstance as PixiWindLayer;
     expect(windLayer.pixiApp).not.toEqual(null);
-    expect(windLayer.pixiApp!.stage.children.length).toEqual(stores.simulation.windIncBounds.length);
+    expect(windLayer.pixiApp!.stage.children.length).toEqual(stores.simulation.windWithinBounds.length);
   });
 
   it("ensures that number of Pixi objects is always equal to number of wind arrows", () => {
     const wrapper = mount(
       <Provider stores={stores}>
-        <Map center={[0, 0]} zoom={10}>
+        <Map center={[0, 0]} zoom={4}>
           <PixiWindLayer/>
         </Map>
       </Provider>
     );
-    const arrowsCount = stores.simulation.windIncBounds.length;
+    const arrowsCount = stores.simulation.windWithinBounds.length;
 
     const windLayer = (wrapper.find(PixiWindLayer).instance() as any).wrappedInstance as PixiWindLayer;
     expect(windLayer.pixiApp).not.toEqual(null);
     expect(windLayer.pixiApp!.stage.children.length).toEqual(arrowsCount);
 
     const newBounds = {
-      getWest: () => -10,
-      getEast: () => 10,
-      getNorth: () => 10,
-      getSouth: () => -10,
+      getWest: () => -40,
+      getEast: () => 40,
+      getNorth: () => 40,
+      getSouth: () => -40,
     };
     stores.simulation.updateBounds((newBounds as any) as Leaflet.LatLngBounds);
 
-    const newArrowsCount = stores.simulation.windIncBounds.length;
+    const newArrowsCount = stores.simulation.windWithinBounds.length;
     expect(newArrowsCount).toBeLessThan(arrowsCount);
     expect(windLayer.pixiApp!.stage.children.length).toEqual(newArrowsCount);
   });

--- a/src/components/pixi-wind-layer.tsx
+++ b/src/components/pixi-wind-layer.tsx
@@ -40,7 +40,7 @@ const arrowTexture = (() => {
 
 // Use this function to tweak visual length of the wind arrows.
 const arrowLengthFunc = (vec: IVector) => {
-  return Math.pow(4 * Math.sqrt(vec.u * vec.u + vec.v * vec.v), 0.55) + 2;
+  return Math.pow(4 * Math.sqrt(vec.u * vec.u + vec.v * vec.v), 0.55) + 4;
 };
 
 interface IProps extends IBaseProps {}

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -4,6 +4,7 @@ import {
 import config from "../config";
 import { PNG } from "pngjs";
 import {distanceTo} from "geolocation-utils";
+import * as Leaflet from "leaflet";
 const fs = require("fs");
 
 const options: ISimulationOptions = {
@@ -128,6 +129,38 @@ describe("SimulationModel store", () => {
         expect(p.u).toBeGreaterThan(-35);
         expect(p.v).toBeGreaterThan(79);
         expect(p.v).toBeLessThan(80);
+      });
+    });
+
+    describe("windWithinBounds", () => {
+      it("changes depending on bounds", () => {
+        const sim = new SimulationModel(options);
+        let newBounds = {
+          getWest: () => -180,
+          getEast: () => 180, // area width 360
+          getNorth: () => 85,
+          getSouth: () => -85,
+        };
+        sim.updateBounds((newBounds as any) as Leaflet.LatLngBounds);
+        expect(sim.windWithinBounds.length).toEqual(1); // every nth wind vector
+
+        newBounds = {
+          getWest: () => -45,
+          getEast: () => 45, // area width 90
+          getNorth: () => 45,
+          getSouth: () => -45,
+        };
+        sim.updateBounds((newBounds as any) as Leaflet.LatLngBounds);
+        expect(sim.windWithinBounds.length).toEqual(2); // all the vectors
+
+        newBounds = {
+          getWest: () => -20,
+          getEast: () => 20,  // area width < 40
+          getNorth: () => 20,
+          getSouth: () => -20,
+        };
+        sim.updateBounds((newBounds as any) as Leaflet.LatLngBounds);
+        expect(sim.windWithinBounds.length).toEqual(961); // 31 * 31 = 661 -> vectors generated using given range
       });
     });
   });


### PR DESCRIPTION
[#164462549]

Before, when the user was zooming in, we weren't increasing number of arrows. So, the vector field was very sparse and arrows looked relatively small. Instead of the increasing size of the arrow, I decided to increase their number, as it gives us a more precise image of the wind field.

