### PR TITLE
Disable UI elements while simulation is running

### DIFF
--- a/src/components/playback-buttons.tsx
+++ b/src/components/playback-buttons.tsx
@@ -19,13 +19,13 @@ export class PlaybackButtons extends BaseComponent<IProps, IState> {
     return [
       <Button
         key="start-stop"
-        onClick={sim.simulationStarted ? sim.stop : sim.start}
+        onClick={sim.simulationRunning ? sim.stop : sim.start}
         disabled={!sim.ready}
         className={css.playbackButton}
         data-test="start-button"
         disableRipple={true}
       >
-        { sim.simulationStarted ? <span><PauseIcon/> Stop</span> : <span><StartIcon /> Start</span> }
+        { sim.simulationRunning ? <span><PauseIcon/> Stop</span> : <span><StartIcon /> Start</span> }
       </Button>,
       <Button
         key="reset"

--- a/src/components/pressure-system-icon.scss
+++ b/src/components/pressure-system-icon.scss
@@ -11,10 +11,13 @@
   margin-top: -60px !important;
   outline: none;
   transition: background-color 350ms;
+  &.disabled {
+    cursor: default;
+  }
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.25);
-    &.disabled{
+    &.disabled {
       cursor: default;
       background-color: rgba(255, 255, 255, 0.0);
     }

--- a/src/components/pressure-system-icon.scss
+++ b/src/components/pressure-system-icon.scss
@@ -14,12 +14,19 @@
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.25);
+    &.disabled{
+      cursor: default;
+      background-color: rgba(255, 255, 255, 0.0);
+    }
     .dragIcon {
       visibility: visible;
+      &.disabled {
+        visibility: hidden;
+      }
     }
   }
 
-  .dragIcon, .dragIconDisabled {
+  .dragIcon {
     visibility: hidden;
     margin-top: 8px;
     svg {

--- a/src/components/pressure-system-icon.scss
+++ b/src/components/pressure-system-icon.scss
@@ -19,7 +19,7 @@
     }
   }
 
-  .dragIcon {
+  .dragIcon, .dragIconDisabled {
     visibility: hidden;
     margin-top: 8px;
     svg {

--- a/src/components/pressure-system-icon.test.tsx
+++ b/src/components/pressure-system-icon.test.tsx
@@ -4,6 +4,7 @@ import { createStores } from "../models/stores";
 import { Provider } from "mobx-react";
 import { PressureSystemIcon, minStrength, maxStrength, mbLabelRange } from "./pressure-system-icon";
 import Slider from "@material-ui/lab/Slider";
+import * as css from "./pressure-system-icon.scss";
 
 describe("PressureSystemIcon component", () => {
   let stores = createStores();
@@ -52,5 +53,17 @@ describe("PressureSystemIcon component", () => {
     expect(icon.renderLabel()).toEqual(
       1010 - Math.round((1000000 - minStrength) / (maxStrength - minStrength) * mbLabelRange) + "mb"
     );
+  });
+
+  it("icon and sliders are disabled while model is running", () => {
+    stores.simulation.simulationStarted = true;
+    const model = stores.simulation.pressureSystems[0];
+    const wrapper = mount(
+      <Provider stores={stores}>
+        <PressureSystemIcon model={model}/>
+      </Provider>
+    );
+    const pressureIcon = wrapper.find('[data-test="pressure-system-icon"]').first();
+    expect(pressureIcon.hasClass(css.disabled)).toEqual(true);
   });
 });

--- a/src/components/pressure-system-icon.test.tsx
+++ b/src/components/pressure-system-icon.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from "mobx-react";
 import { PressureSystemIcon, minStrength, maxStrength, mbLabelRange } from "./pressure-system-icon";
 import Slider from "@material-ui/lab/Slider";
 import * as css from "./pressure-system-icon.scss";
+import config from "../config";
 
 describe("PressureSystemIcon component", () => {
   let stores = createStores();
@@ -55,7 +56,7 @@ describe("PressureSystemIcon component", () => {
     );
   });
 
-  it("icon and sliders are disabled while model is running", () => {
+  it("icon and sliders are disabled while model is running by default", () => {
     stores.simulation.simulationStarted = true;
     const model = stores.simulation.pressureSystems[0];
     const wrapper = mount(
@@ -65,5 +66,24 @@ describe("PressureSystemIcon component", () => {
     );
     const pressureIcon = wrapper.find('[data-test="pressure-system-icon"]').first();
     expect(pressureIcon.hasClass(css.disabled)).toEqual(true);
+
+    const pressureIconSlider = wrapper.find('[data-test="pressure-system-slider"]').first();
+    expect(pressureIconSlider.prop("disabled")).toEqual(true);
+  });
+
+  it("icon and sliders can be enabled while model is running", () => {
+    stores.simulation.simulationStarted = true;
+    config.lockSimulationWhileRunning = false;
+    const model = stores.simulation.pressureSystems[0];
+    const wrapper = mount(
+      <Provider stores={stores}>
+        <PressureSystemIcon model={model}/>
+      </Provider>
+    );
+    const pressureIcon = wrapper.find('[data-test="pressure-system-icon"]').first();
+    expect(pressureIcon.hasClass(css.disabled)).toEqual(false);
+
+    const pressureIconSlider = wrapper.find('[data-test="pressure-system-slider"]').first();
+    expect(pressureIconSlider.prop("disabled")).toEqual(false);
   });
 });

--- a/src/components/pressure-system-icon.tsx
+++ b/src/components/pressure-system-icon.tsx
@@ -36,8 +36,8 @@ export class PressureSystemIcon extends BaseComponent<IProps, IState> {
     const uiDisabled = config.lockSimulationWhileRunning && sim.simulationStarted;
 
     return (
-      <div className={css.pressureSystemIcon}>
-        <div className={uiDisabled ? css.dragIconDisabled : css.dragIcon}><DragIcon /></div>
+      <div className={`${css.pressureSystemIcon} ${uiDisabled ? css.disabled : ""}`}>
+        <div className={`${css.dragIcon} ${uiDisabled ? css.disabled : ""}`}><DragIcon /></div>
         {
           model.type === "high" ?
             <High className={css.letter} style={letterStyle} /> :

--- a/src/components/pressure-system-icon.tsx
+++ b/src/components/pressure-system-icon.tsx
@@ -36,7 +36,10 @@ export class PressureSystemIcon extends BaseComponent<IProps, IState> {
     const uiDisabled = config.lockSimulationWhileRunning && sim.simulationStarted;
 
     return (
-      <div className={`${css.pressureSystemIcon} ${uiDisabled ? css.disabled : ""}`}>
+      <div
+        className={`${css.pressureSystemIcon} ${uiDisabled ? css.disabled : ""}`}
+        data-test="pressure-system-icon"
+      >
         <div className={`${css.dragIcon} ${uiDisabled ? css.disabled : ""}`}><DragIcon /></div>
         {
           model.type === "high" ?
@@ -55,6 +58,7 @@ export class PressureSystemIcon extends BaseComponent<IProps, IState> {
             vertical={true}
             thumb={<VerticalHandle />}
             disabled={uiDisabled}
+            data-test={"pressure-system-slider"}
           />
         </div>
         <div className={css.label}>

--- a/src/components/pressure-system-icon.tsx
+++ b/src/components/pressure-system-icon.tsx
@@ -27,6 +27,7 @@ export class PressureSystemIcon extends BaseComponent<IProps, IState> {
 
   public render() {
     const { model, onSliderDragStart, onSliderDragEnd } = this.props;
+    const sim = this.stores.simulation;
     const strengthNorm = (model.strength - minStrength) / (maxStrength - minStrength) - 0.5; // [-0.5, 0.5]
     const letterScale = 1 + strengthNorm * 0.3; // adjust level of visual scaling
     const letterStyle = { transform: `scale3d(${letterScale},${letterScale},${letterScale})` };
@@ -49,6 +50,7 @@ export class PressureSystemIcon extends BaseComponent<IProps, IState> {
             onDragEnd={onSliderDragEnd}
             vertical={true}
             thumb={<VerticalHandle />}
+            disabled={sim.simulationStarted && !sim.simulationFinished}
           />
         </div>
         <div className={css.label}>

--- a/src/components/pressure-system-icon.tsx
+++ b/src/components/pressure-system-icon.tsx
@@ -7,6 +7,7 @@ import VerticalHandle from "../assets/slider-vertical.svg";
 import High from "../assets/high.svg";
 import Low from "../assets/low.svg";
 import DragIcon from "../assets/drag.svg";
+import config from "../config";
 
 import * as css from "./pressure-system-icon.scss";
 
@@ -31,6 +32,8 @@ export class PressureSystemIcon extends BaseComponent<IProps, IState> {
     const strengthNorm = (model.strength - minStrength) / (maxStrength - minStrength) - 0.5; // [-0.5, 0.5]
     const letterScale = 1 + strengthNorm * 0.3; // adjust level of visual scaling
     const letterStyle = { transform: `scale3d(${letterScale},${letterScale},${letterScale})` };
+    // If set to lock the UI while the simulation is running, lock UI once the sim is started until it is reset
+    const uiDisabled = config.lockSimulationWhileRunning && sim.simulationStarted;
     return (
       <div className={css.pressureSystemIcon}>
         <div className={css.dragIcon}><DragIcon /></div>
@@ -41,7 +44,7 @@ export class PressureSystemIcon extends BaseComponent<IProps, IState> {
         }
         <div className={css.sliderContainer}>
           <Slider
-            classes={{thumb: css.thumb, track: css.track}}
+            classes={{ thumb: css.thumb, track: css.track }}
             value={model.strength}
             min={minStrength}
             max={maxStrength}
@@ -50,7 +53,7 @@ export class PressureSystemIcon extends BaseComponent<IProps, IState> {
             onDragEnd={onSliderDragEnd}
             vertical={true}
             thumb={<VerticalHandle />}
-            disabled={sim.simulationStarted && !sim.simulationFinished}
+            disabled={uiDisabled}
           />
         </div>
         <div className={css.label}>

--- a/src/components/pressure-system-icon.tsx
+++ b/src/components/pressure-system-icon.tsx
@@ -34,9 +34,10 @@ export class PressureSystemIcon extends BaseComponent<IProps, IState> {
     const letterStyle = { transform: `scale3d(${letterScale},${letterScale},${letterScale})` };
     // If set to lock the UI while the simulation is running, lock UI once the sim is started until it is reset
     const uiDisabled = config.lockSimulationWhileRunning && sim.simulationStarted;
+
     return (
       <div className={css.pressureSystemIcon}>
-        <div className={css.dragIcon}><DragIcon /></div>
+        <div className={uiDisabled ? css.dragIconDisabled : css.dragIcon}><DragIcon /></div>
         {
           model.type === "high" ?
             <High className={css.letter} style={letterStyle} /> :

--- a/src/components/pressure-system-marker.tsx
+++ b/src/components/pressure-system-marker.tsx
@@ -4,6 +4,7 @@ import { BaseComponent, IBaseProps } from "./base";
 import { PressureSystem } from "../models/pressure-system";
 import { PressureSystemIcon } from "./pressure-system-icon";
 import { LeafletCustomMarker } from "./leaflet-custom-marker";
+import config from "../config";
 import * as Leaflet from "leaflet";
 
 interface IProps extends IBaseProps {
@@ -22,13 +23,14 @@ export class PressureSystemMarker extends BaseComponent<IProps, IState> {
     const { model } = this.props;
     const { sliderDrag } = this.state;
     const sim = this.stores.simulation;
+    const uiDisabled = config.lockSimulationWhileRunning && sim.simulationStarted;
     return (
       <LeafletCustomMarker
         position={model.center}
         onDrag={this.handlePressureSysDrag}
         onDragEnd={this.handlePressureSysDragEnd}
         // Disable dragging when slider is being dragged, so they don't interfere.
-        draggable={!sliderDrag && !sim.simulationStarted && !sim.simulationRunning}
+        draggable={!sliderDrag && !uiDisabled}
       >
         <PressureSystemIcon
           model={model}

--- a/src/components/pressure-system-marker.tsx
+++ b/src/components/pressure-system-marker.tsx
@@ -21,13 +21,14 @@ export class PressureSystemMarker extends BaseComponent<IProps, IState> {
   public render() {
     const { model } = this.props;
     const { sliderDrag } = this.state;
+    const sim = this.stores.simulation;
     return (
       <LeafletCustomMarker
         position={model.center}
         onDrag={this.handlePressureSysDrag}
         onDragEnd={this.handlePressureSysDragEnd}
         // Disable dragging when slider is being dragged, so they don't interfere.
-        draggable={!sliderDrag}
+        draggable={!sliderDrag && !sim.simulationStarted && !sim.simulationRunning}
       >
         <PressureSystemIcon
           model={model}

--- a/src/components/season-button.scss
+++ b/src/components/season-button.scss
@@ -13,7 +13,7 @@
     width: 76px;
     height: 42px;
     background: #FF8F20;
-    border-radius: 10px;
+    border-radius: 8px;
     text-transform: capitalize;
     display: flex;
     align-items: center;

--- a/src/components/season-button.scss
+++ b/src/components/season-button.scss
@@ -7,6 +7,10 @@
   border-bottom-left-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
 
+  &.disabled{
+    opacity: 0.5 !important;
+  }
+
   .seasonValue {
     color: #fff;
     font-size: 12px;

--- a/src/components/season-button.test.tsx
+++ b/src/components/season-button.test.tsx
@@ -4,6 +4,7 @@ import { createStores } from "../models/stores";
 import { Provider } from "mobx-react";
 import { SeasonButton } from "./season-button";
 import Button from "@material-ui/core/Button";
+import * as css from "./season-button.scss";
 
 describe("SeasonButton component", () => {
   let stores = createStores();
@@ -39,5 +40,16 @@ describe("SeasonButton component", () => {
     wrapper.find(Button).simulate("click");
     expect(stores.simulation.season).toEqual("fall");
     expect(wrapper.text()).toEqual(expect.stringContaining("fall"));
+  });
+
+  it("season button is disabled while model is running", () => {
+    stores.simulation.simulationStarted = true;
+    const wrapper = mount(
+      <Provider stores={stores}>
+        <SeasonButton />
+      </Provider>
+    );
+    const seasonButton = wrapper.find('[data-test="season-button"]').first();
+    expect(seasonButton.hasClass(css.disabled)).toEqual(true);
   });
 });

--- a/src/components/season-button.tsx
+++ b/src/components/season-button.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { BaseComponent, IBaseProps } from "./base";
 import Button from "@material-ui/core/Button";
 import { Season } from "../types";
+import config from "../config";
 
 import * as css from "./season-button.scss";
 
@@ -16,13 +17,15 @@ const seasons: Season[] = [ "fall", "winter", "spring", "summer" ];
 export class SeasonButton extends BaseComponent<IProps, IState> {
   public render() {
     const sim = this.stores.simulation;
+    // If set to lock the UI while the simulation is running, lock UI once the sim is started until it is reset
+    const uiDisabled = config.lockSimulationWhileRunning && sim.simulationStarted;
     return (
       <Button
         onClick={this.handleSeasonChange}
         className={css.seasonButton}
         data-test="season-button"
         disableTouchRipple={true}
-        disabled={sim.simulationStarted && !sim.simulationFinished}
+        disabled={uiDisabled}
       >
         <div>
           <div className={css.seasonValue}>{ sim.season }</div>

--- a/src/components/season-button.tsx
+++ b/src/components/season-button.tsx
@@ -22,6 +22,7 @@ export class SeasonButton extends BaseComponent<IProps, IState> {
         className={css.seasonButton}
         data-test="season-button"
         disableTouchRipple={true}
+        disabled={sim.simulationStarted && !sim.simulationFinished}
       >
         <div>
           <div className={css.seasonValue}>{ sim.season }</div>

--- a/src/components/season-button.tsx
+++ b/src/components/season-button.tsx
@@ -22,7 +22,7 @@ export class SeasonButton extends BaseComponent<IProps, IState> {
     return (
       <Button
         onClick={this.handleSeasonChange}
-        className={css.seasonButton}
+        className={`${css.seasonButton} ${uiDisabled ? css.disabled : ""}`}
         data-test="season-button"
         disableTouchRipple={true}
         disabled={uiDisabled}

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,8 @@ const DEFAULT_CONFIG: any = {
   // --- UI elements can be shown or hidden using options below ---
   seasonButton: true,
   windArrowsSlider: true,
-  seaSurfaceTempSlider: true
+  seaSurfaceTempSlider: true,
+  lockSimulationWhileRunning: true
   // --- End of UI widgets ---
 };
 

--- a/src/material-ui-theme.tsx
+++ b/src/material-ui-theme.tsx
@@ -26,7 +26,7 @@ export default createMuiTheme({
         },
         "&$disabled": {
           color: "inherit",
-          opacity: 0.25
+          opacity: 0.5
         }
       },
       text: {
@@ -43,14 +43,24 @@ export default createMuiTheme({
         "height": 1,
         "&$vertical": {
           width: 1
+        },
+        "&$disabled": {
+          color: "inherit",
+          opacity: 0.25
         }
       },
       trackAfter: {
         opacity: 1
       },
       thumbIconWrapper: {
-        width: "20px",
-        height: "20px"
+        "width": "20px",
+        "height": "20px",
+
+        "&$disabled": {
+          width: "20px",
+          height: "20px",
+          opacity: 0.25
+        }
       },
       thumb: {
         "&$focused, &:hover": {
@@ -58,6 +68,9 @@ export default createMuiTheme({
         },
         "&$activated": {
           boxShadow: "0 0 0 3px rgba(255,255,255,0.85)"
+        },
+        "&$disabled": {
+          boxShadow: 0
         }
       }
     }

--- a/src/material-ui-theme.tsx
+++ b/src/material-ui-theme.tsx
@@ -26,7 +26,7 @@ export default createMuiTheme({
         },
         "&$disabled": {
           color: "inherit",
-          opacity: 0.5
+          opacity: 0.25
         }
       },
       text: {

--- a/src/material-ui-theme.tsx
+++ b/src/material-ui-theme.tsx
@@ -46,7 +46,8 @@ export default createMuiTheme({
         },
         "&$disabled": {
           color: "inherit",
-          opacity: 0.25
+          opacity: 0.25,
+          cursor: "default"
         }
       },
       trackAfter: {

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -183,6 +183,7 @@ describe("SimulationModel store", () => {
     });
 
     it("reports correct SST value", (done) => {
+      jest.setTimeout(10000);
       global.fetch.mockResponseOnce(fs.readFileSync("./sea-surface-temp-img/sep.png"));
       const sim = new SimulationModel(options);
       sim._seaSurfaceTempDataParsed = () => {
@@ -273,30 +274,36 @@ describe("SimulationModel store", () => {
       sim.hurricaneTrack = [{category: 1, position: {lat: 33, lng: 123}}];
       sim.landfalls = [{category: 1, position: {lat: 33, lng: 123}}];
       sim.numberOfStepsOverSea = 123;
+      sim.simulationStarted = true;
       sim.reset();
       expect(sim.time).toEqual(0);
       expect(sim.hurricane.reset).toHaveBeenCalled();
       expect(sim.hurricaneTrack.length).toEqual(0);
       expect(sim.landfalls.length).toEqual(0);
       expect(sim.numberOfStepsOverSea).toEqual(0);
+      expect(sim.simulationStarted).toEqual(false);
     });
   });
 
   describe("start", () => {
     it("starts the simulation", () => {
       const sim = new SimulationModel(options);
+      expect(sim.simulationRunning).toEqual(false);
       expect(sim.simulationStarted).toEqual(false);
       sim.start();
+      expect(sim.simulationRunning).toEqual(true);
       expect(sim.simulationStarted).toEqual(true);
     });
   });
 
   describe("stop", () => {
-    it("stops the simulation", () => {
+    it("stops the simulation without resetting it", () => {
       const sim = new SimulationModel(options);
       sim.simulationStarted = true;
+      sim.simulationRunning = true;
       sim.stop();
-      expect(sim.simulationStarted).toEqual(false);
+      expect(sim.simulationRunning).toEqual(false);
+      expect(sim.simulationStarted).toEqual(true);
     });
   });
 

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -107,6 +107,7 @@ export class SimulationModel {
   });
 
   @observable public simulationStarted = false;
+  @observable public simulationRunning = false;
 
   @observable public landfalls: ILandfall[] = [];
 
@@ -292,23 +293,27 @@ export class SimulationModel {
       this.simulationFinished = true;
     }
 
-    if (this.simulationStarted) {
+    if (this.simulationRunning) {
       requestAnimationFrame(this.tick);
     }
   }
 
   @action.bound public start() {
-    this.simulationStarted = true;
+    this.simulationRunning = true;
+    if (!this.simulationStarted) {
+      this.simulationStarted = true;
+    }
     this.tick();
   }
 
   @action.bound public stop() {
-    this.simulationStarted = false;
+    this.simulationRunning = false;
   }
 
   @action.bound public reset() {
-    this.simulationStarted = false;
+    this.simulationRunning = false;
     this.simulationFinished = false;
+    this.simulationStarted = false;
     this.hurricaneTrack = [];
     this.landfalls = [];
     this.time = 0;


### PR DESCRIPTION
Addressing [#164602464] this disables all adjustment of pressure systems and disables the season change button after the simulation has started, and leaves them disabled until the simulation is reset.

This behavior can be disabled via the `lockSimulationWhileRunning` configuration value.