### PR TITLE
Fix canvas layer resize logic

### DIFF
--- a/src/components/pixi-wind-layer.tsx
+++ b/src/components/pixi-wind-layer.tsx
@@ -79,7 +79,7 @@ export class PixiWindLayer extends BaseComponent<IProps, IState> {
         resolution: window.devicePixelRatio
       });
     }
-    this.pixiApp.renderer.resize(info.canvas.width, info.canvas.height);
+    this.pixiApp.renderer.resize(parseInt(info.canvas.style.width), parseInt(info.canvas.style.height));
     this.pixiApp.render();
   }
 

--- a/src/components/pixi-wind-layer.tsx
+++ b/src/components/pixi-wind-layer.tsx
@@ -79,7 +79,7 @@ export class PixiWindLayer extends BaseComponent<IProps, IState> {
         resolution: window.devicePixelRatio
       });
     }
-    this.pixiApp.renderer.resize(parseInt(info.canvas.style.width), parseInt(info.canvas.style.height));
+    this.pixiApp.renderer.resize(parseInt(info.canvas.style.width, 10), parseInt(info.canvas.style.height, 10));
     this.pixiApp.render();
   }
 

--- a/src/components/react-leaflet-canvas-layer.tsx
+++ b/src/components/react-leaflet-canvas-layer.tsx
@@ -145,11 +145,11 @@ const LeafletCanvasLayer = (Layer || Class).extend({
     DomUtil.setPosition(this.canvas, topLeft);
 
     const size = this._map.getSize();
-    if (this.canvas.width !== size.x) {
+    if (this.canvas.style.width !== size.x + "px") {
       this.canvas.width = size.x;
       this.canvas.style.width = size.x + "px";
     }
-    if (this.canvas.height !== size.y) {
+    if (this.canvas.style.height !== size.y + "px") {
       this.canvas.height = size.y;
       this.canvas.style.height = size.y + "px";
     }


### PR DESCRIPTION
[#163062700]

Use canvas.style.width/height as source of truth instead of canvas.width/height.
Main width/height can be different from map size e.g. when renderer
is handling HDPI displays and doubling canvas dimensions.