### PR TITLE
Add storm surge overlay in zoomed-in view

### DIFF
--- a/src/components/landfall-rectangle.tsx
+++ b/src/components/landfall-rectangle.tsx
@@ -39,6 +39,7 @@ export class LandfallRectangle extends BaseComponent<IProps, IState> {
   }
 
   public handleClick = () => {
-    this.stores.ui.setZoomedInView(this.getBounds());
+    const { category } = this.props;
+    this.stores.ui.setZoomedInView(this.getBounds(), category);
   }
 }

--- a/src/components/map-button.tsx
+++ b/src/components/map-button.tsx
@@ -13,6 +13,7 @@ interface IProps extends IBaseProps {
   label: string;
   value: GeoMap | Overlay;
   mapType: MapType;
+  disabled?: boolean;
 }
 interface IState {}
 
@@ -20,7 +21,7 @@ interface IState {}
 @observer
 export class MapButton extends BaseComponent<IProps, IState> {
   public render() {
-    const { label, mapType, value } = this.props;
+    const { label, mapType, value, disabled } = this.props;
     const ui = this.stores.ui;
 
     const active = mapType === "geo" && ui.mapTile.mapType === value ||
@@ -51,6 +52,7 @@ export class MapButton extends BaseComponent<IProps, IState> {
         className={`${css.mapButton} ${buttonClass}`}
         data-test="map-button"
         disableRipple={true}
+        disabled={disabled}
         style={buttonStyle}
       >
         <span className={`${css.mapLabel} ${buttonClass} ${active ? css.active : ""}`}>{labelText}</span>

--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -58,4 +58,28 @@ describe("MapView component", () => {
     wrapper.update();
     expect(wrapper.find(HurricaneMarker).length).toEqual(0);
   });
+
+  it("renders storm surge overlay in zoomed-in view", () => {
+    const wrapper = mount(
+      <Provider stores={stores}>
+        <MapView />
+      </Provider>
+    );
+    expect(wrapper.find({
+      url: "https://tiles.arcgis.com/tiles/C8EMgrsFcRFL6LrL/arcgis/rest/services/NHC_NationalMOM_Category" +
+        "3_CONUS/MapServer/tile/{z}/{y}/{x}"
+    }).length).toEqual(0);
+
+    stores.ui.zoomedInView = {
+      landfallCategory: 3,
+      stormSurgeAvailable: true
+    };
+    stores.ui.overlay = "stormSurge";
+    wrapper.update();
+
+    expect(wrapper.find({
+      url: "https://tiles.arcgis.com/tiles/C8EMgrsFcRFL6LrL/arcgis/rest/services/NHC_NationalMOM_Category" +
+           "3_CONUS/MapServer/tile/{z}/{y}/{x}"
+    }).length).toBeGreaterThan(0);
+  });
 });

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -92,6 +92,16 @@ export class MapView extends BaseComponent<IProps, IState> {
             bounds={imageOverlayBounds}
           />
           {
+            // Source:
+            // https://noaa.maps.arcgis.com/apps/MapSeries/index.html?appid=d9ed7904dbec441a9c4dd7b277935fad&entry=1
+            ui.overlay === "stormSurge" && ui.zoomedInView && ui.zoomedInView.stormSurgeAvailable &&
+            <TileLayer
+              url={`https://tiles.arcgis.com/tiles/C8EMgrsFcRFL6LrL/arcgis/rest/services/NHC_NationalMOM_Category` +
+                   `${ui.zoomedInView.landfallCategory}_CONUS/MapServer/tile/{z}/{y}/{x}`}
+              opacity={0.75}
+            />
+          }
+          {
             ui.overlay === "precipitation" && <PrecipitationLayer/>
           }
           <HurricaneTrack />

--- a/src/components/right-panel.test.tsx
+++ b/src/components/right-panel.test.tsx
@@ -3,7 +3,7 @@ import { mount } from "enzyme";
 import { createStores } from "../models/stores";
 import { Provider } from "mobx-react";
 import { RightPanel } from "./right-panel";
-import { MapTab } from "./map-tab";
+import { MapButton } from "./map-button";
 
 describe("Right Panel component", () => {
   let stores = createStores();
@@ -83,6 +83,31 @@ describe("Right Panel component", () => {
     // geo panel now hidden, impact is visible
     expect(wrapper.find('[data-test="geo-panel"]').length).toEqual(0);
     expect(wrapper.find('[data-test="impact-panel"]').exists());
+  });
+
+  it("renders disabled storm surge button unless zoomed in view is active", () => {
+    const wrapper = mount(
+      <Provider stores={stores}>
+        <RightPanel />
+      </Provider>
+    );
+    wrapper.find("#impact").simulate("click");
+    expect(wrapper.find({
+      label: "Storm Surge", value: "stormSurge", mapType: "impact", disabled: true
+    }).length).toBeGreaterThan(0); // for some reason length is 2. Impossible looking at the code. Enzyme/Jest issue?
+
+    stores.ui.zoomedInView = {
+      landfallCategory: 3,
+      stormSurgeAvailable: true
+    };
+    wrapper.update();
+
+    expect(wrapper.find({
+      label: "Storm Surge", value: "stormSurge", mapType: "impact", disabled: true
+    }).length).toEqual(0);
+    expect(wrapper.find({
+      label: "Storm Surge", value: "stormSurge", mapType: "impact", disabled: false
+    }).length).toBeGreaterThan(0); // for some reason length is 2. Impossible looking at the code. Enzyme/Jest issue?
   });
 
 });

--- a/src/components/right-panel.tsx
+++ b/src/components/right-panel.tsx
@@ -27,6 +27,7 @@ export class RightPanel extends BaseComponent<IProps, IState> {
 
   public render() {
     const { open, selectedTab } = this.state;
+    const { ui } = this.stores;
     return (
       <div className={css.rightPanelContainer}>
         <div className={`${css.rightPanel} ${open ? css.open : ""}`} data-test="right-panel">
@@ -53,6 +54,7 @@ export class RightPanel extends BaseComponent<IProps, IState> {
                 <div className={css.tabContent}>
                   <div className={css.drawerTitle}>Impact Maps</div>
                   <MapButton label="Precipitation" value="precipitation" mapType={"impact"} />
+                  <MapButton label="Storm Surge" value="stormSurge" mapType={"impact"} disabled={!ui.zoomedInView} />
                 </div>
             </div>
           }

--- a/src/models/ui.test.ts
+++ b/src/models/ui.test.ts
@@ -46,11 +46,23 @@ describe("UI model", () => {
   });
 
   describe("setZoomedInView", () => {
-    it("updates initialBounds", () => {
+    it("updates initialBounds and zoomedInView props", () => {
       const ui = new UIModel();
-      ui.setZoomedInView([[1, 2], [5, 10]]);
-      expect(ui.initialBounds).toEqual([[1, 2], [5, 10]]);
-      expect(ui.zoomedInView).toEqual(true);
+      ui.setZoomedInView([[30, -85], [35, -80]], 3);
+      expect(ui.initialBounds).toEqual([[30, -85], [35, -80]]);
+      expect(ui.zoomedInView).toEqual({
+        landfallCategory: 3,
+        stormSurgeAvailable: true
+      });
+
+      // Note that boudns are out of bounds of the region that has storm surge data defined.
+      // See: `stormSurgeDataBounds` const in ui.ts.
+      ui.setZoomedInView([[1, -80], [5, -80]], 1);
+      expect(ui.initialBounds).toEqual([[1, -80], [5, -80]]);
+      expect(ui.zoomedInView).toEqual({
+        landfallCategory: 1,
+        stormSurgeAvailable: false
+      });
     });
   });
 


### PR DESCRIPTION
[#164170986]

This PR adds storm surge overlay in zoomed-in view using tiles available from arcgis.