### PR TITLE
Reimplement buffer zone around pressure systems

### DIFF
--- a/src/components/pressure-system-marker.tsx
+++ b/src/components/pressure-system-marker.tsx
@@ -28,7 +28,6 @@ export class PressureSystemMarker extends BaseComponent<IProps, IState> {
       <LeafletCustomMarker
         position={model.center}
         onDrag={this.handlePressureSysDrag}
-        onDragEnd={this.handlePressureSysDragEnd}
         // Disable dragging when slider is being dragged, so they don't interfere.
         draggable={!sliderDrag && !uiDisabled}
       >
@@ -44,11 +43,6 @@ export class PressureSystemMarker extends BaseComponent<IProps, IState> {
   public handlePressureSysDrag = (e: Leaflet.LeafletMouseEvent) => {
     const { model } = this.props;
     this.stores.simulation.setPressureSysCenter(model, e.latlng);
-  }
-
-  private handlePressureSysDragEnd = () => {
-    const { model } = this.props;
-    this.stores.simulation.checkPressureSystem(model);
   }
 
   private handleDrag = () => {

--- a/src/models/pressure-system.test.ts
+++ b/src/models/pressure-system.test.ts
@@ -1,4 +1,5 @@
 import { IPressureSystemOptions, PressureSystem } from "./pressure-system";
+import config from "../config";
 
 describe("PressureSystem store", () => {
   const defOptions: IPressureSystemOptions = {
@@ -39,6 +40,23 @@ describe("PressureSystem store", () => {
       expect(pressureSystem.center).not.toBe(options.center);
       expect(pressureSystem.strength).toEqual(options.strength);
       expect(pressureSystem.type).toEqual(options.type);
+    });
+  });
+
+  describe("setCenter", () => {
+    it("should ensure that a new center is not too close to other pressure systems", () => {
+      const oldMinDist = config.minPressureSystemDistance;
+      config.minPressureSystemDistance = 800000;
+      const ps1 = new PressureSystem({ center: { lat: 20, lng: 20 } });
+      const otherPs = [
+        new PressureSystem({ center: { lat: 20, lng: 30 } }),
+        new PressureSystem({ center: { lat: 20, lng: 40 } })
+      ];
+      ps1.setCenter({ lat: 20, lng: 25 }, otherPs);
+      expect(ps1.center.lng).toBeCloseTo(22.32);
+      ps1.setCenter({ lat: 20, lng: 35 }, otherPs);
+      expect(ps1.center.lng).toBeCloseTo(47.69);
+      config.minPressureSystemDistance = oldMinDist;
     });
   });
 });

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -257,11 +257,7 @@ export class SimulationModel {
   }
 
   @action.bound public setPressureSysCenter(pressureSystem: PressureSystem, center: ICoordinates) {
-    pressureSystem.setCenter(center, this.pressureSystems);
-  }
-
-  @action.bound public checkPressureSystem(pressureSystem: PressureSystem) {
-    pressureSystem.checkPressureSystem(this.pressureSystems);
+    pressureSystem.setCenter(center, this.pressureSystems.filter(ps => ps !== pressureSystem));
   }
 
   @action.bound public tick(timestamp = window.performance.now()) {


### PR DESCRIPTION
[#167792283]

When user tries to drag one pressure system too close to another one, the model will immediately calculate a new, correct position.

The previous implementation was simpler and less restrictive (or incorrect as this feature has been requested) and less intuitive for users. The pressure system was jumping back to the hopefully correct position after dragging was finished.

Demo:
http://hurricane.concord.org/branch/buffer/index.html