### PR TITLE
Seasons button => Seasons popup menu [#179595440]

### DIFF
--- a/cypress/integration/basic.test.ts
+++ b/cypress/integration/basic.test.ts
@@ -8,15 +8,28 @@ context("Test the Hurricane Model app", () => {
   });
 
   it("lets user change season", () => {
-    cy.contains(".season-button--seasonValue--__hurr-v1__", "fall");
-    cy.get('[data-test="season-button"]').click();
-    cy.contains(".season-button--seasonValue--__hurr-v1__", "winter");
-    cy.get('[data-test="season-button"]').click();
-    cy.contains(".season-button--seasonValue--__hurr-v1__", "spring");
-    cy.get('[data-test="season-button"]').click();
-    cy.contains(".season-button--seasonValue--__hurr-v1__", "summer");
-    cy.get('[data-test="season-button"]').click();
-    cy.contains(".season-button--seasonValue--__hurr-v1__", "fall");
+    // defaults to Fall
+    cy.contains(".season-button--seasonSelect--__hurr-v1__", "Fall");
+    // can change to Winter
+    cy.get('[data-test="season-button"]')
+      .click()
+      .then(() => {
+        cy.get('[data-test="season-item-winter"]')
+          .click()
+          .then(() => {
+            cy.contains(".season-button--seasonSelect--__hurr-v1__", "Winter");
+          });
+      });
+    // can change to Spring
+    cy.get('[data-test="season-button"]')
+      .click()
+      .then(() => {
+        cy.get('[data-test="season-item-spring"]')
+          .click()
+          .then(() => {
+            cy.contains(".season-button--seasonSelect--__hurr-v1__", "Spring");
+          });
+      });
   });
 
   it("lets user start and stop the model", () => {

--- a/src/components/bottom-bar.scss
+++ b/src/components/bottom-bar.scss
@@ -69,6 +69,11 @@ $overflowHeight: 11px;
     background: $hoverColor;
   }
 
+  // for programmatic control of hover state
+  .hovered {
+    background: $hoverColor;
+  }
+
   .reloadRestart {
     margin-left: 10px;
     white-space: nowrap;

--- a/src/components/bottom-bar.test.tsx
+++ b/src/components/bottom-bar.test.tsx
@@ -23,7 +23,7 @@ describe("BottomBar component", () => {
     expect(wrapper.find(SeasonButton).length).toEqual(1);
     expect(wrapper.find(WindArrowsToggle).length).toEqual(1);
     expect(wrapper.find(HurricaneImageToggle).length).toEqual(1);
-    expect(wrapper.find(Button).length).toEqual(4);
+    expect(wrapper.find(Button).length).toEqual(3);
   });
 
   it("start button is disabled until model is ready", () => {

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -21,6 +21,7 @@ import * as css from "./bottom-bar.scss";
 interface IProps extends IBaseProps {}
 interface IState {
   fullscreen: boolean;
+  isSeasonMenuOpen: boolean;
 }
 
 function toggleFullscreen() {
@@ -42,7 +43,8 @@ export class BottomBar extends BaseComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
-      fullscreen: false
+      fullscreen: false,
+      isSeasonMenuOpen: false
     };
   }
 
@@ -64,6 +66,8 @@ export class BottomBar extends BaseComponent<IProps, IState> {
 
   public render() {
     const sim = this.stores.simulation;
+    const { isSeasonMenuOpen } = this.state;
+    const seasonButtonHoveredClass = isSeasonMenuOpen ? css.hovered : "";
     return (
       <div className={css.bottomBar}>
         <div className={css.leftContainer}>
@@ -73,8 +77,13 @@ export class BottomBar extends BaseComponent<IProps, IState> {
         <div className={css.mainContainer}>
           {
             config.seasonButton &&
-            <div className={css.widgetGroup}>
-              <SeasonButton />
+            <div className={`${css.widgetGroup} hoverable ${seasonButtonHoveredClass}`}>
+              <SeasonButton
+                onMenuOpen={() => this.setState({ isSeasonMenuOpen: true })}
+                onMenuClose={() => {
+                  // delay to avoid flash between closing menu and :hover taking over
+                  setTimeout(() => this.setState({ isSeasonMenuOpen: false }), 500);
+                }} />
             </div>
           }
           <div className={`${css.widgetGroup} hoverable`}>

--- a/src/components/season-button.scss
+++ b/src/components/season-button.scss
@@ -1,40 +1,56 @@
 @import "common.scss";
 
 .seasonButton {
-  width: 92px;
-  height: 100%;
-  overflow: hidden;
-  border-bottom-left-radius: 0 !important;
-  border-bottom-right-radius: 0 !important;
+  margin-top: $bottomBarTopPadding;
+  width: 96px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   &.disabled{
     opacity: 0.5 !important;
   }
 
-  .seasonValue {
-    color: #fff;
-    font-size: 12px;
-    width: 76px;
-    height: 42px;
-    background: #FF8F20;
-    border-radius: 8px;
-    text-transform: capitalize;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border: $bottomBarBorderStyle;
-    margin-top: $bottomBarTopPadding;
-
-    &:hover {
-      box-shadow: 0 0 0 3px rgba(255,255,255,0.5)
-    }
-    &:active {
-      box-shadow: 0 0 0 3px rgba(255,255,255,1)
-    }
-  }
-
   .seasonLabel {
     font-size: 12px;
-    margin-bottom: 8px;
+    text-align: center;
   }
+
+  .selectContainer {
+    margin-top: 8px;
+    width: 82px;
+    height: 26px;
+    border-radius: 8px;
+    background: rgba(255,255,255,0);
+    &:hover {
+      background: rgba(255,255,255,0.5);
+    }
+
+    .seasonSelect {
+      left: 3px;
+      top: 3px;
+      width: 76px;
+      height: 20px;
+      font-size: 11px;
+      border: 1px solid black;
+      border-radius: 5px;
+      background: white;
+
+      &:hover {
+        background: $hoverColor;
+      }
+    }
+  }
+}
+
+.seasonItem {
+  padding: 0 8px !important;
+  width: 74px !important;
+  font-size: 11px !important;
+  display: flex;
+  justify-content: space-between !important;
+}
+
+:global(.MuiSelect-select:focus) {
+  background: none !important;
 }

--- a/src/components/season-button.test.tsx
+++ b/src/components/season-button.test.tsx
@@ -3,7 +3,7 @@ import { mount } from "enzyme";
 import { createStores } from "../models/stores";
 import { Provider } from "mobx-react";
 import { SeasonButton } from "./season-button";
-import Button from "@material-ui/core/Button";
+import Select from "@material-ui/core/Select";
 import * as css from "./season-button.scss";
 
 describe("SeasonButton component", () => {
@@ -18,28 +18,7 @@ describe("SeasonButton component", () => {
         <SeasonButton />
       </Provider>
     );
-    expect(wrapper.find(Button).length).toEqual(1);
-  });
-
-  it("switches season on click", () => {
-    const wrapper = mount(
-      <Provider stores={stores}>
-        <SeasonButton />
-      </Provider>
-    );
-    expect(stores.simulation.season).toEqual("fall");
-    wrapper.find(Button).simulate("click");
-    expect(stores.simulation.season).toEqual("winter");
-    expect(wrapper.text()).toEqual(expect.stringContaining("winter"));
-    wrapper.find(Button).simulate("click");
-    expect(stores.simulation.season).toEqual("spring");
-    expect(wrapper.text()).toEqual(expect.stringContaining("spring"));
-    wrapper.find(Button).simulate("click");
-    expect(stores.simulation.season).toEqual("summer");
-    expect(wrapper.text()).toEqual(expect.stringContaining("summer"));
-    wrapper.find(Button).simulate("click");
-    expect(stores.simulation.season).toEqual("fall");
-    expect(wrapper.text()).toEqual(expect.stringContaining("fall"));
+    expect(wrapper.find(Select).length).toEqual(1);
   });
 
   it("season button is disabled while model is running", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,3 +28,9 @@ export interface ILandfall {
 }
 
 export type Season = "winter" | "spring" | "summer" | "fall";
+export const seasonLabels: Record<Season, string> = {
+  winter: "Winter",
+  spring: "Spring",
+  summer: "Summer",
+  fall: "Fall"
+};

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
     "interface-name" : false,
     "jsx-alignment": false,
     "jsx-curly-spacing": false,
+    "jsx-no-lambda": false,
     "jsx-no-multiline-js": false,
     "jsx-wrap-multiline": false,
     "max-classes-per-file": false,


### PR DESCRIPTION
PT: [[#179595440]](https://www.pivotaltracker.com/story/show/179595440)

Demo: https://hurricane.concord.org/branch/seasons-menu/index.html

Replacing the button with a popup menu (MaterialUI Select) was trivial. Getting it to look something like the spec took quite a bit longer.

Notes:
- I updated the cypress test of the season-changing behavior and eliminated the jest test of the same behavior as fixing it didn't seem worth the time.
- I also disabled tslint's `jsx-no-lambda` as it seems outdated at this point.