### PR TITLE
Add configuration to disable Population map support

### DIFF
--- a/src/components/about-dialog-content.tsx
+++ b/src/components/about-dialog-content.tsx
@@ -1,18 +1,22 @@
 import * as React from "react";
+import config from "../config";
 import {Copyright} from "./copyright";
 
 export class AboutDialogContent extends React.Component {
   public render() {
+    const baseMapList = config.enablePopulationMap
+                          ? "Satellite, Relief, Street or Population"
+                          : "Satellite, Relief or Street";
     return (
       <div>
         <p>
           Meteorologists use models to explore the formation and motion of storms and hurricanes. Use this model to
           explore factors that affect the intensity and track of hurricanes in the Atlantic Ocean such as the location
           and strength of low and high pressure systems and changes in sea surface temperature. This model includes
-          basemaps and overlays of real-world data that can be used to consider potential risk and impact of
+          base maps and overlays of real-world data that can be used to consider potential risk and impact of
           hurricanes on people and the environment.
         </p>
-        <p>Use the Geo Maps tab to select a base map: satellite, street or relief.</p>
+        <p>Use the Base Maps tab to select a base map: {baseMapList}.</p>
         <p>Adjust the location and intensity of the high and low pressure systems.</p>
         <p>
           Click the play button to see the track of the hurricane. How does the storm track change in strength and
@@ -20,8 +24,8 @@ export class AboutDialogContent extends React.Component {
         </p>
         <p>Change seasons by clicking the season button. Which seasons produce the highest category hurricanes?</p>
         <p>
-          Use the Overlay Maps tab to add a data layer showing sea surface temperature, population, precipitation and
-          storm surge. Explore how hurricanes impact communities in their path.
+          Use the Map Overlays tab to add a data layer showing sea surface temperature, precipitation or storm surge.
+          Explore how hurricanes impact communities in their path.
         </p>
         <p>
           Hurricane Explorer was created

--- a/src/components/map-button.tsx
+++ b/src/components/map-button.tsx
@@ -62,7 +62,7 @@ export class MapButton extends BaseComponent<IProps, IState> {
       <Button
         onClick={this.handleMapSelect}
         className={`${css.mapButton} ${buttonClass}`}
-        data-test="map-button"
+        data-test={`map-button-${value}`}
         disableRipple={true}
         disabled={disabled}
       >

--- a/src/components/map-tab.tsx
+++ b/src/components/map-tab.tsx
@@ -20,7 +20,7 @@ export class MapTab extends BaseComponent<IProps, IState> {
     const { tabType, active } = this.props;
     const tabStyle = tabType === "base" ? css.geoMaps : css.impactMaps;
     const activeStyle = active ? css.active : "";
-    const tabText = tabType === "base" ? "Base Maps" : "Maps Overlays";
+    const tabText = tabType === "base" ? "Base Maps" : "Map Overlays";
     const tabMap = {
       backgroundImage: ""
     };

--- a/src/components/right-panel.test.tsx
+++ b/src/components/right-panel.test.tsx
@@ -20,9 +20,9 @@ describe("Right Panel component", () => {
     expect(wrapper.find(RightPanel).length).toBe(1);
     expect(wrapper.find("ul").length).toBe(1);
     expect(wrapper.find("li").length).toBe(2);
-    // default is the geo panel
+    // default is the base maps panel
     expect(wrapper.find('[data-test="base-panel"]').exists()).toEqual(true);
-    // impact panel is not rendered until the tab is clicked
+    // overlay panel is not rendered until the tab is clicked
     expect(wrapper.find('[data-test="overlay-panel"]').length).toEqual(0);
   });
 
@@ -37,7 +37,7 @@ describe("Right Panel component", () => {
     expect(panel.state.open).toBe(false);
     wrapper.find("#base").simulate("click");
     expect(panel.state.open).toBe(true);
-    // looking at geo panel, no impact panel rendered
+    // looking at base maps panel, no overlay panel rendered
     expect(wrapper.find('[data-test="base-panel"]').exists()).toEqual(true);
     expect(wrapper.find('[data-test="overlay-panel"]').length).toEqual(0);
   });
@@ -70,7 +70,33 @@ describe("Right Panel component", () => {
     expect(panel.state.open).toBe(false);
   });
 
-  it("renders the impact panel when the impact tab is clicked", () => {
+  it("provides the population base map option when configured to do so", () => {
+    const defaultValue = config.enablePopulationMap;
+
+    config.enablePopulationMap = true;
+    let wrapper = mount(
+      <Provider stores={stores}>
+        <RightPanel />
+      </Provider>
+    );
+    wrapper.find("#base").simulate("click");
+    expect(wrapper.find('[data-test="base-panel"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="map-button-population"]').exists()).toBe(true);
+
+    config.enablePopulationMap = false;
+    wrapper = mount(
+      <Provider stores={stores}>
+        <RightPanel />
+      </Provider>
+    );
+    wrapper.find("#base").simulate("click");
+    expect(wrapper.find('[data-test="base-panel"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="map-button-population"]').exists()).toBe(false);
+
+    config.enablePopulationMap = defaultValue;
+  });
+
+  it("renders the overlay panel when the overlay tab is clicked", () => {
     const wrapper = mount(
       <Provider stores={stores}>
         <RightPanel />
@@ -80,7 +106,7 @@ describe("Right Panel component", () => {
     expect(panel.state.open).toBe(false);
     wrapper.find("#overlay").simulate("click");
     expect(panel.state.open).toBe(true);
-    // geo panel now hidden, impact is visible
+    // base maps panel now hidden, overlay is visible
     expect(wrapper.find('[data-test="base-panel"]').length).toEqual(0);
     expect(wrapper.find('[data-test="overlay-panel"]').exists()).toEqual(true);
   });

--- a/src/components/right-panel.tsx
+++ b/src/components/right-panel.tsx
@@ -68,7 +68,8 @@ export class RightPanel extends BaseComponent<IProps, IState> {
                 <MapButton label="Satellite" value="satellite" mapType="base" />
                 <MapButton label="Relief" value="relief" mapType="base" />
                 <MapButton label="Street" value="street" mapType="base" />
-                <MapButton label="Population" value="population" mapType="base" />
+                {config.enablePopulationMap &&
+                  <MapButton label="Population" value="population" mapType="base" />}
               </div>
             </div>
           }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ const DEFAULT_CONFIG: any = {
   season: "fall",
   // One of the available maps: "satellite", "relief", "street" or "population".
   map: "satellite",
+  enablePopulationMap: false,
   // Enabled map overlay. One of the values listed in "availableOverlays".
   overlay: "sst",
   // LatLngBoundsLiteral: [[lat, lng], [lat, lng]]. Defaults to North Atlantic.

--- a/src/map-layer-tiles.ts
+++ b/src/map-layer-tiles.ts
@@ -43,6 +43,8 @@ const layerInfo: MapTileLayer[] = [
     subdomains: []
   },
   {
+    // Note: As of 2021-Oct, this url is no longer in service. We have configured the model not to display
+    // the population map option (config.enablePopulationMap: false) until a replacement is found.
     mapType: "population",
     name: "Population",
     // tslint:disable-next-line:max-line-length

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -11,7 +11,7 @@ export type Overlay = "sst" | "precipitation" | "stormSurge";
 export type ZoomedInViewProps = false | { landfallCategory: number; stormSurgeAvailable: boolean; };
 
 export class UIModel {
-    @observable public initialBounds = config.initialBounds;
+  @observable public initialBounds = config.initialBounds;
   @observable public zoomedInView: ZoomedInViewProps = false;
   @observable public mapModifiedByUser = false;
   @observable public layerOpacity: { [key: string]: number } = {
@@ -28,6 +28,9 @@ export class UIModel {
 
   constructor() {
     this.initialState = JSON.parse(JSON.stringify(this));
+    if ((this.initialState.baseMap === "population") && !config.enablePopulationMap) {
+      this.initialState.baseMap = "street";
+    }
   }
   @observable public latLngToContainerPoint: (arg: LatLngExpression) => Point = () => new Point(0, 0);
 


### PR DESCRIPTION
PT: [[#179942178]](https://www.pivotaltracker.com/story/show/179942178)

Demo: https://hurricane.concord.org/branch/no-population/index.html

Add the `enablePopulationMap` configuration value to disable the population map option until a suitable replacement for the previous population map tile server is found.