### PR TITLE
Fix zoomed category markers [#179923985]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5326,6 +5326,58 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+    },
+    "@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
+    },
+    "@turf/line-intersect": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
+      "integrity": "sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/line-segment": "^6.5.0",
+        "@turf/meta": "^6.5.0",
+        "geojson-rbush": "3.x"
+      }
+    },
+    "@turf/line-segment": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.5.0.tgz",
+      "integrity": "sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.16",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
@@ -5398,8 +5450,7 @@
     "@types/geojson": {
       "version": "7946.0.8",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
-      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
-      "dev": true
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
     },
     "@types/glob": {
       "version": "7.1.4",
@@ -7066,7 +7117,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -10342,7 +10394,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -11356,6 +11409,18 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
+    },
+    "geojson-rbush": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
+      "integrity": "sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==",
+      "requires": {
+        "@turf/bbox": "*",
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x",
+        "@types/geojson": "7946.0.8",
+        "rbush": "^3.0.1"
+      }
     },
     "geolocation-utils": {
       "version": "1.2.5",
@@ -18367,6 +18432,11 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
+    "quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -18526,6 +18596,14 @@
             "ajv-keywords": "^3.5.2"
           }
         }
+      }
+    },
+    "rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "requires": {
+        "quickselect": "^2.0.0"
       }
     },
     "rc": {
@@ -19951,7 +20029,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -126,6 +126,8 @@
     "@concord-consortium/lara-interactive-api": "^1.1.2",
     "@material-ui/core": "4.12.3",
     "@material-ui/icons": "^4.11.2",
+    "@turf/helpers": "^6.5.0",
+    "@turf/line-intersect": "^6.5.0",
     "d3-scale": "^3.3.0",
     "geolocation-utils": "1.2.5",
     "jquery": "^3.6.0",

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -263,6 +263,24 @@ describe("SimulationModel store", () => {
       expect(sim.getCategoryMarkerPositions(mapBounds))
         .toEqual([{ position: { lat: 2, lng: -2 }, category: 0 }, { position: { lat: 4, lng: -4 }, category: 1 }]);
     });
+    it("should show marker in middle of visible part of segment for single segment spanning beyond bounds", () => {
+      const sim = new SimulationModel(options);
+      sim.hurricaneTrack = [
+        { position: { lat: 1, lng: -7 }, category: 0 },
+        { position: { lat: 1, lng: 6 }, category: 1 }
+      ];
+      sim.strengthChangePositions = [0, 1];
+      expect(sim.getCategoryMarkerPositions(mapBounds)).toEqual([{ position: { lat: 1, lng: 0 }, category: 0 }]);
+    });
+    it("should show marker in middle of visible part of segment for segment spanning partially beyond bounds", () => {
+      const sim = new SimulationModel(options);
+      sim.hurricaneTrack = [
+        { position: { lat: 1, lng: -3 }, category: 0 },
+        { position: { lat: 1, lng: 6 }, category: 1 }
+      ];
+      sim.strengthChangePositions = [0, 1];
+      expect(sim.getCategoryMarkerPositions(mapBounds)).toEqual([{ position: { lat: 1, lng: 1 }, category: 0 }]);
+    });
   });
 
   describe("tick", () => {

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -489,11 +489,6 @@ export class SimulationModel {
   }
 
   // Note that the visibility testing here is based on testing hurricane track segment end points.
-  // It is possible for the user to zoom in far enough that only a single track segment is visible
-  // and both of its ends are off screen. In that case, no category label will be displayed. This
-  // seems like an edge case that is not worth additional effort, but if it were deemed necessary
-  // it would require detecting this case and calculating the intersection between the track
-  // segment and the map boundaries.
   public getCategoryMarkerPositions(bounds: LatLngBounds) {
     const markerPositions: ITrackPoint[] = [];
     let prevTrackIndex = 0;


### PR DESCRIPTION
PT: [[#179923985]](https://www.pivotaltracker.com/story/show/179923985)

Demo: https://hurricane.concord.org/branch/zoom-marker/index.html

Since I was back in the hurricane code addressing the issue with the temperature tool, I decided to take another look at the issue of category markers not appearing when zoomed in. I found a library that handles the determination of the intersections of the line segments with the visible bounds and after that the code was fairly straightforward so I went ahead and implemented it.

Under the hood, we now handle a single visible segment as a special case and attempt to place the category marker in the middle of the visible part of the segment.