### PR TITLE
HIdes vertical scroll when embedded in LARA

### DIFF
--- a/src/components/right-panel.scss
+++ b/src/components/right-panel.scss
@@ -15,6 +15,7 @@ $mapTabVerticalSpacing: 10px;
   top: $topBarHeight;
   right: 0;
   pointer-events: none;
+  overflow-y: hidden;
 
   .rightPanel {
     position: absolute;


### PR DESCRIPTION
Right tabs shows a vertical scroll bar when embedded in LARA in 60-40. This hides it.