### PR TITLE
feat: gulf hurricanes start location & path (HURR-3)

### DIFF
--- a/src/components/select-button.tsx
+++ b/src/components/select-button.tsx
@@ -40,7 +40,7 @@ export const SelectButton: React.FC<ISelectButtonProps> = (props) => {
           onClose={onMenuClose}
         >
           {menuItems.map(item => (
-            <MenuItem key={item.value} className={css.menuItem} value={item.value}>
+            <MenuItem key={item.value} value={item.value}>
               <div data-test={item.testId}>{item.label}</div>
             </MenuItem>
           ))}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import {LatLngBoundsLiteral} from "leaflet";
+import { PressureSystemType } from "./models/pressure-system";
 
 function getURLParam(name: string) {
   const url = (self || window).location.href;
@@ -9,6 +10,65 @@ function getURLParam(name: string) {
   if (!results[2]) return true;
   return decodeURIComponent(results[2].replace(/\+/g, " "));
 }
+
+// Start position-specific pressure systems
+const atlanticStartHighPressure = {
+  type: "high" as PressureSystemType,
+  center: {lat: 28, lng: -30},
+  strength: 19.5
+};
+
+const atlanticStartLowPressure = {
+  type: "low" as PressureSystemType,
+  center: {lat: 45, lng: -82},
+  strength: 6
+};
+
+const gulfStartHighPressure = {
+  type: "high" as PressureSystemType,
+  center: {lat: 34.5, lng: -107},
+  strength: 9.54
+};
+
+const gulfStartLowPressure = {
+  type: "low" as PressureSystemType,
+  center: {lat: 38, lng: -95},
+  strength: 17.39
+};
+
+// Shared pressure systems (used for both start positions)
+const sharedHighPressure = {
+  type: "high" as PressureSystemType,
+  center: {lat: 28.8, lng: -62.4},
+  strength: 13.6
+};
+
+const sharedLowPressure = {
+  type: "low" as PressureSystemType,
+  center: {lat: 47, lng: -60},
+  strength: 7
+};
+
+export const selectPressureSystems = (startLocation: string) => {
+  if (startLocation === "atlantic") {
+    return [
+      atlanticStartHighPressure,
+      sharedHighPressure,
+      sharedLowPressure,
+      atlanticStartLowPressure
+    ];
+  } else if (startLocation === "gulf") {
+    return [
+      gulfStartHighPressure,
+      sharedHighPressure,
+      sharedLowPressure,
+      gulfStartLowPressure
+    ];
+  }
+  return [];
+};
+
+const DEFAULT_START_LOCATION = "atlantic";
 
 const DEFAULT_CONFIG: any = {
   authoring: false,
@@ -21,28 +81,7 @@ const DEFAULT_CONFIG: any = {
   overlay: "sst",
   // LatLngBoundsLiteral: [[lat, lng], [lat, lng]]. Defaults to North Atlantic.
   initialBounds: [[5, -90], [50, -10]],
-  pressureSystems: [
-    {
-      type: "high",
-      center: {lat: 28, lng: -30},
-      strength: 19.5
-    },
-    {
-      type: "high",
-      center: {lat: 28.8, lng: -62.4},
-      strength: 13.6
-    },
-    {
-      type: "low",
-      center: {lat: 45, lng: -82},
-      strength: 6
-    },
-    {
-      type: "low",
-      center: {lat: 47, lng: -60},
-      strength: 7
-    }
-  ],
+  pressureSystems: selectPressureSystems(DEFAULT_START_LOCATION),
   availableOverlays: [
     "sst",
     "precipitation",
@@ -60,7 +99,7 @@ const DEFAULT_CONFIG: any = {
   landTemperature: 22,
   // Wind shear is present in winter and spring and it will cause hurricanes to die pretty fast.
   windShearStrength: 0.0015,
-  initialHurricanePosition: "atlantic",
+  initialHurricanePosition: DEFAULT_START_LOCATION,
   initialHurricaneSpeed: {u: 0, v: 0},
   // When wind is far enough from the center of the pressure system, pressure system effect is lower
   // and we start smoothing it out.

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,41 +13,41 @@ function getURLParam(name: string) {
 
 // Start position-specific pressure systems
 const atlanticStartHighPressure = {
-  type: "high" as PressureSystemType,
+  type: "high",
   center: {lat: 28, lng: -30},
   strength: 19.5
-};
+} as const;
 
 const atlanticStartLowPressure = {
-  type: "low" as PressureSystemType,
+  type: "low",
   center: {lat: 45, lng: -82},
   strength: 6
-};
+} as const;
 
 const gulfStartHighPressure = {
-  type: "high" as PressureSystemType,
+  type: "high",
   center: {lat: 34.5, lng: -107},
   strength: 9.54
-};
+} as const;
 
 const gulfStartLowPressure = {
-  type: "low" as PressureSystemType,
+  type: "low",
   center: {lat: 38, lng: -95},
   strength: 17.39
-};
+} as const;
 
 // Shared pressure systems (used for both start positions)
 const sharedHighPressure = {
-  type: "high" as PressureSystemType,
+  type: "high",
   center: {lat: 28.8, lng: -62.4},
   strength: 13.6
-};
+} as const;
 
 const sharedLowPressure = {
-  type: "low" as PressureSystemType,
+  type: "low",
   center: {lat: 47, lng: -60},
   strength: 7
-};
+} as const;
 
 export const selectPressureSystems = (startLocation: string) => {
   if (startLocation === "atlantic") {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
-import {LatLngBoundsLiteral} from "leaflet";
-import { PressureSystemType } from "./models/pressure-system";
+import { StartLocationNames } from "./types";
 
 function getURLParam(name: string) {
   const url = (self || window).location.href;
@@ -56,8 +55,8 @@ const pressureSystems = {
   ]
 } as const;
 
-export const selectPressureSystems = (startLocation: string) => {
-  const locationSystems = pressureSystems[startLocation as keyof typeof pressureSystems] || pressureSystems.atlantic;
+export const selectPressureSystems = (startLocation: StartLocationNames) => {
+  const locationSystems = pressureSystems[startLocation] || pressureSystems.atlantic;
   return [...locationSystems, sharedLowPressure];
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,61 +11,54 @@ function getURLParam(name: string) {
   return decodeURIComponent(results[2].replace(/\+/g, " "));
 }
 
-// Start position-specific pressure systems
-const atlanticStartHighPressure = {
-  type: "high",
-  center: {lat: 28, lng: -30},
-  strength: 19.5
-} as const;
-
-const atlanticStartLowPressure = {
-  type: "low",
-  center: {lat: 45, lng: -82},
-  strength: 6
-} as const;
-
-const gulfStartHighPressure = {
-  type: "high",
-  center: {lat: 34.5, lng: -107},
-  strength: 9.54
-} as const;
-
-const gulfStartLowPressure = {
-  type: "low",
-  center: {lat: 38, lng: -95},
-  strength: 17.39
-} as const;
-
-// Shared pressure systems (used for both start positions)
-const sharedHighPressure = {
-  type: "high",
-  center: {lat: 28.8, lng: -62.4},
-  strength: 13.6
-} as const;
-
+// Shared pressure system (used for both start positions)
 const sharedLowPressure = {
   type: "low",
   center: {lat: 47, lng: -60},
   strength: 7
 } as const;
 
+// Start position-specific pressure systems
+const pressureSystems = {
+  atlantic: [
+    {
+      type: "high",
+      center: {lat: 28, lng: -30},
+      strength: 19.5
+    },
+    {
+      type: "high",
+      center: {lat: 28.8, lng: -62.4},
+      strength: 13.6
+    },
+    {
+      type: "low",
+      center: {lat: 45, lng: -82},
+      strength: 6
+    }
+  ],
+  gulf: [
+    {
+      type: "high",
+      center: {lat: 37, lng: -107.1},
+      strength: 15.5
+    },
+    {
+      type: "high",
+      center: {lat: 33, lng: -67.5},
+      strength: 9.54
+    },
+    {
+      type: "low",
+      center: {lat: 39.15, lng: -91},
+      strength: 15
+    }
+  ]
+} as const;
+
 export const selectPressureSystems = (startLocation: string) => {
-  if (startLocation === "atlantic") {
-    return [
-      atlanticStartHighPressure,
-      sharedHighPressure,
-      sharedLowPressure,
-      atlanticStartLowPressure
-    ];
-  } else if (startLocation === "gulf") {
-    return [
-      gulfStartHighPressure,
-      sharedHighPressure,
-      sharedLowPressure,
-      gulfStartLowPressure
-    ];
-  }
-  return [];
+  const locationSystems = pressureSystems[startLocation as keyof typeof pressureSystems] || pressureSystems.atlantic;
+  return [...locationSystems, sharedLowPressure];
 };
 
 const DEFAULT_START_LOCATION = "atlantic";

--- a/src/material-ui-theme.tsx
+++ b/src/material-ui-theme.tsx
@@ -37,6 +37,12 @@ export default createTheme({
         padding: 0,
       }
     },
+    MuiMenuItem: {
+      root: {
+        fontSize: "11px",
+        padding: "6px",
+      }
+    },
     MuiSwitch: {
       root: {
         padding: 14

--- a/src/models/pressure-system.ts
+++ b/src/models/pressure-system.ts
@@ -18,13 +18,19 @@ export interface IPressureSystemOptions {
 const minLat = 15;
 
 const minDistToOtherSystems = (center: ICoordinates, otherSystems: PressureSystem[]) => {
-  const dists = otherSystems.map(ps => distanceTo(ps.center, center));
+  const dists = otherSystems.map(ps => distanceTo(
+    {lat: ps.center.lat, lon: ps.center.lng},
+    {lat: center.lat, lon: center.lng}
+  ));
   let minDist = Infinity;
   let heading = null;
   for (let i = 0; i < dists.length; i += 1) {
     if (dists[i] < minDist) {
       minDist = dists[i];
-      heading = headingTo(center, otherSystems[i].center);
+      heading = headingTo(
+        {lat: center.lat, lon: center.lng},
+        {lat: otherSystems[i].center.lat, lon: otherSystems[i].center.lng}
+      );
     }
   }
   return { minDist, heading };
@@ -54,14 +60,16 @@ export class PressureSystem {
     wind = Object.assign({}, wind);
     const direction = this.type === "high" ? 1 : -1;
     const offset = this.type === "high" ? config.highPressureSysAngleOffset : config.lowPressureSysAngleOffset;
-    const heading = headingTo(this.center, wind) + 90 * direction - offset;
-    const distNormalized = distanceTo(this.center, wind) / this.range;
+    const ctrLat = this.center.lat;
+    const ctrLon = this.center.lng;
+    const heading = headingTo({lat: ctrLat, lon: ctrLon}, {lat: wind.lat, lon: wind.lng}) + 90 * direction - offset;
+    const distNormalized = distanceTo({lat: ctrLat, lon: ctrLon}, {lat: wind.lat, lon: wind.lng}) / this.range;
     const exp = this.type === "high" ? 0.25 : 4;
     const distExp = Math.pow(distNormalized, exp);
     const length = this.type === "high" ? distExp * this.strength : (1 - distExp) * this.strength;
-    const newPos = moveTo(wind, {distance: length, heading});
-    const u = distanceTo({lng: newPos.lng, lat: 0}, {lng: wind.lng, lat: 0}) * (newPos.lng > wind.lng ? 1 : -1);
-    const v = distanceTo({lng: 0, lat: newPos.lat}, {lng: 0, lat: wind.lat}) * (newPos.lat > wind.lat ? 1 : -1);
+    const newPos = moveTo({lat: wind.lat, lon: wind.lng}, {distance: length, heading});
+    const u = distanceTo({lat: 0, lon: newPos.lon}, {lat: 0, lon: wind.lng}) * (newPos.lon > wind.lng ? 1 : -1);
+    const v = distanceTo({lat: newPos.lat, lon: 0}, {lat: wind.lat, lon: 0}) * (newPos.lat > wind.lat ? 1 : -1);
     let newWind = { u, v };
     if (distNormalized > config.smoothPressureSystemRatio) {
       const ratio = (distNormalized - config.smoothPressureSystemRatio) / (1 - config.smoothPressureSystemRatio);
@@ -87,14 +95,18 @@ export class PressureSystem {
     center.lat = Math.max(minLat, center.lat);
     const step = config.minPressureSystemDistance / 100;
     const minDistRes = minDistToOtherSystems(center, otherPressureSystems);
-    const heading = minDistRes.heading;
+    const heading = minDistRes.heading || 0; // Provide default heading if null
     let minDist = minDistRes.minDist;
     // Why is an iterative approach used instead of a single calculation based on the minPressureSystemDistance
     // and heading? Note this single calculation could result in new center being to close to another pressure system.
     // Iterative calculations ensure that we'll always end up away from *all* the pressure systems. Initial heading
     // is used, so the interaction feels a bit more natural for user.
     while (minDist < config.minPressureSystemDistance) {
-      center = moveTo(center, { distance: step, heading: heading + 180 });
+      const newPos = moveTo(
+        {lat: center.lat, lon: center.lng},
+        { distance: step, heading: heading + 180 }
+      );
+      center = { lat: newPos.lat, lng: newPos.lon };
       minDist = minDistToOtherSystems(center, otherPressureSystems).minDist;
     }
     this.center = center;

--- a/src/models/pressure-system.ts
+++ b/src/models/pressure-system.ts
@@ -60,10 +60,9 @@ export class PressureSystem {
     wind = Object.assign({}, wind);
     const direction = this.type === "high" ? 1 : -1;
     const offset = this.type === "high" ? config.highPressureSysAngleOffset : config.lowPressureSysAngleOffset;
-    const ctrLat = this.center.lat;
-    const ctrLon = this.center.lng;
-    const heading = headingTo({lat: ctrLat, lon: ctrLon}, {lat: wind.lat, lon: wind.lng}) + 90 * direction - offset;
-    const distNormalized = distanceTo({lat: ctrLat, lon: ctrLon}, {lat: wind.lat, lon: wind.lng}) / this.range;
+    const { lat: ctrLat, lng: ctrLng } = this.center;
+    const heading = headingTo({lat: ctrLat, lon: ctrLng}, {lat: wind.lat, lon: wind.lng}) + 90 * direction - offset;
+    const distNormalized = distanceTo({lat: ctrLat, lon: ctrLng}, {lat: wind.lat, lon: wind.lng}) / this.range;
     const exp = this.type === "high" ? 0.25 : 4;
     const distExp = Math.pow(distNormalized, exp);
     const length = this.type === "high" ? distExp * this.strength : (1 - distExp) * this.strength;

--- a/src/models/pressure-system.ts
+++ b/src/models/pressure-system.ts
@@ -103,9 +103,9 @@ export class PressureSystem {
     while (minDist < config.minPressureSystemDistance) {
       const newPos = moveTo(
         {lat: center.lat, lon: center.lng},
-        { distance: step, heading: heading + 180 }
+        {distance: step, heading: heading + 180}
       );
-      center = { lat: newPos.lat, lng: newPos.lon };
+      center = {lat: newPos.lat, lng: newPos.lon};
       minDist = minDistToOtherSystems(center, otherPressureSystems).minDist;
     }
     this.center = center;

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -6,6 +6,7 @@ import { PNG } from "pngjs";
 import * as Leaflet from "leaflet";
 const mockFetch = require("jest-fetch-mock");
 const fs = require("fs");
+import { PressureSystem } from "./pressure-system";
 
 const options: ISimulationOptions = {
   startLocation: "atlantic",
@@ -368,14 +369,7 @@ describe("SimulationModel store", () => {
     it("restarts hurricane simulation without changing some of the initial conditions", () => {
       const sim = new SimulationModel({
         startLocation: "atlantic",
-        season: "fall",
-        pressureSystems: [
-          {
-            type: "high",
-            center: {lat: 10, lng: 0},
-            strength: 13
-          }
-        ]
+        season: "fall"
       });
       sim.hurricane.reset = jest.fn();
       sim.pressureSystems[0].reset = jest.fn();
@@ -408,22 +402,26 @@ describe("SimulationModel store", () => {
     it("triggers restart and resets initial conditions", () => {
       const sim = new SimulationModel({
         startLocation: "atlantic",
-        season: "fall",
-        pressureSystems: [
-          {
-            type: "high",
-            center: {lat: 10, lng: 0},
-            strength: 13
-          }
-        ]
+        season: "fall"
       });
       jest.spyOn(sim, "restart");
-      sim.pressureSystems[0].reset = jest.fn();
       sim.season = "winter";
+      const initialPressureSystems = [...sim.pressureSystems];
+      // Modify the pressure systems
+      sim.pressureSystems = [
+        new PressureSystem({
+          type: "low",
+          center: {lat: 20, lng: -20},
+          strength: 15
+        })
+      ];
       sim.reset();
       expect(sim.restart).toHaveBeenCalled();
-      expect(sim.pressureSystems[0].reset).toHaveBeenCalled();
       expect(sim.season).toEqual("fall");
+      expect(sim.pressureSystems.length).toEqual(initialPressureSystems.length);
+      expect(sim.pressureSystems[0].type).toEqual(initialPressureSystems[0].type);
+      expect(sim.pressureSystems[0].center).toEqual(initialPressureSystems[0].center);
+      expect(sim.pressureSystems[0].strength).toEqual(initialPressureSystems[0].strength);
     });
   });
 

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -446,6 +446,8 @@ export class SimulationModel {
     this.numberOfStepsOverLand = 0;
     this.extendedLandfallAreas = Object.values(extendedLandfallBounds);
     this.hurricane.reset();
+    const coordinates = resolveStartLocation(this.startLocation);
+    this.hurricane.setCenter(coordinates, this.pressureSystems);
     if (this.pressureSystemSettings.length) {
       this.pressureSystems = this.pressureSystemSettings;
     }
@@ -457,6 +459,13 @@ export class SimulationModel {
     this.pressureSystems.forEach(ps => ps.reset());
     this.startLocation = this.initialState.startLocation;
     this.season = this.initialState.season;
+    const coordinates = resolveStartLocation(this.startLocation);
+    this.hurricane.setCenter(coordinates, this.pressureSystems);
+    if (isStartLocationName(this.startLocation)) {
+      this.pressureSystems = selectPressureSystems(this.startLocation).map(
+        (o: IPressureSystemOptions) => new PressureSystem(o)
+      );
+    }
   }
 
   @action.bound public removePressureSystem(ps: PressureSystem) {

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -270,7 +270,6 @@ export class SimulationModel {
     const coordinates = resolveStartLocation(startLocation);
     this.hurricane.setCenter(coordinates, this.pressureSystems);
 
-    // Update pressure systems if start location is a named location.
     if (isStartLocationName(startLocation)) {
       this.pressureSystems = selectPressureSystems(startLocation).map(
         (o: IPressureSystemOptions) => new PressureSystem(o)

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -19,7 +19,7 @@ import { vecAverage } from "../math-utils";
 import { distanceTo } from "geolocation-utils";
 import { invertedTemperatureScale } from "../temperature-scale";
 import { PNG } from "pngjs";
-import config from "../config";
+import config, { selectPressureSystems } from "../config";
 import { random } from "../seedrandom";
 
 interface IWindDataset {
@@ -269,6 +269,13 @@ export class SimulationModel {
     this.startLocation = startLocation;
     const coordinates = resolveStartLocation(startLocation);
     this.hurricane.setCenter(coordinates, this.pressureSystems);
+
+    // Update pressure systems if start location is a named location.
+    if (isStartLocationName(startLocation)) {
+      this.pressureSystems = selectPressureSystems(startLocation).map(
+        (o: IPressureSystemOptions) => new PressureSystem(o)
+      );
+    }
   }
 
   @action.bound public setSeason(season: Season) {

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -456,7 +456,6 @@ export class SimulationModel {
   // That's a complete reset to the initial state.
   @action.bound public reset() {
     this.restart();
-    this.pressureSystems.forEach(ps => ps.reset());
     this.startLocation = this.initialState.startLocation;
     this.season = this.initialState.season;
     const coordinates = resolveStartLocation(this.startLocation);


### PR DESCRIPTION
[HURR-3](https://concord-consortium.atlassian.net/browse/HURR-3)

Adds full functionality for the new Start Location menu added in [this earlier PR](https://github.com/concord-consortium/hurricane-model/pull/94).

**Acceptance Criteria**

- When a user selects a hurricane to start in the “Gulf”, the hurricane icon in the model will appear in the Gulf. (This was actually added in the previous PR.)
- When user selects Gulf start location, the High pressure system near Portugal for the Atlantic option moves over the southwestern U.S., and the Low pressure system near the Great Lakes moves to the central U.S.
- All Gulf hurricanes will function with the same rules that govern an Atlantic hurricane.
- Start Location dropdown selection is logged. If user changes to Gulf, log the new selection. (This was actually added in the previous PR.)

[HURR-3]: https://concord-consortium.atlassian.net/browse/HURR-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ