### PR TITLE
HURR-32 Update License

### DIFF
--- a/src/components/hurricane-marker.test.tsx
+++ b/src/components/hurricane-marker.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { createStores } from "../models/stores";
 import { MapContainer } from "react-leaflet";
 import { HurricaneMarker, HurricaneIcon } from "./hurricane-marker";
@@ -36,6 +36,30 @@ describe("HurricaneMarker component", () => {
     renderMarker();
     const draggableEl = document.querySelector(".leaflet-marker-draggable");
     expect(draggableEl).not.toBeNull();
+  });
+
+  it("is not dimmed in stormCategory setup mode", async () => {
+    stores.ui.setSetupMode("stormCategory");
+    stores.simulation.simulationStarted = false;
+    renderMarker();
+    const draggableEl = document.querySelector(".leaflet-marker-draggable");
+    expect(draggableEl).toBeNull();
+    await waitFor(() => {
+      const dimmedEl = document.querySelector(`[data-test="hurricane-marker"].dimmed`);
+      expect(dimmedEl).toBeNull();
+    });
+  });
+
+  it("is dimmed in season setup mode", async () => {
+    stores.ui.setSetupMode("season");
+    stores.simulation.simulationStarted = false;
+    renderMarker();
+    const draggableEl = document.querySelector(".leaflet-marker-draggable");
+    expect(draggableEl).toBeNull();
+    await waitFor(() => {
+      const dimmedEl = document.querySelector(`[data-test="hurricane-marker"].dimmed`);
+      expect(dimmedEl).not.toBeNull();
+    });
   });
 
   it("is not draggable once the simulation has started, even in setup mode", () => {

--- a/src/components/hurricane-marker.test.tsx
+++ b/src/components/hurricane-marker.test.tsx
@@ -45,8 +45,9 @@ describe("HurricaneMarker component", () => {
     const draggableEl = document.querySelector(".leaflet-marker-draggable");
     expect(draggableEl).toBeNull();
     await waitFor(() => {
-      const dimmedEl = document.querySelector(`[data-test="hurricane-marker"].dimmed`);
-      expect(dimmedEl).toBeNull();
+      const markerEl = document.querySelector(`[data-test="hurricane-marker"]`);
+      expect(markerEl).not.toBeNull();
+      expect(markerEl).not.toHaveClass("dimmed");
     });
   });
 
@@ -57,8 +58,9 @@ describe("HurricaneMarker component", () => {
     const draggableEl = document.querySelector(".leaflet-marker-draggable");
     expect(draggableEl).toBeNull();
     await waitFor(() => {
-      const dimmedEl = document.querySelector(`[data-test="hurricane-marker"].dimmed`);
-      expect(dimmedEl).not.toBeNull();
+      const markerEl = document.querySelector(`[data-test="hurricane-marker"]`);
+      expect(markerEl).not.toBeNull();
+      expect(markerEl).toHaveClass("dimmed");
     });
   });
 

--- a/src/components/hurricane-marker.tsx
+++ b/src/components/hurricane-marker.tsx
@@ -86,7 +86,7 @@ export const HurricaneIcon = observer(function HurricaneIcon({ dragging }: IHurr
   const opacity = hurrStrengthToOpacity(hurricane.strength);
 
   const { hurricaneImage, mapZoom, setupMode } = stores.ui;
-  const dimmed = !!setupMode && !["stormLocation", "stormCategory"].includes(setupMode);
+  const dimmed = !!setupMode && !(setupMode === "stormLocation" || setupMode === "stormCategory");
   const draggable = setupMode === "stormLocation";
 
   const getLabel = () => {

--- a/src/components/hurricane-marker.tsx
+++ b/src/components/hurricane-marker.tsx
@@ -86,7 +86,7 @@ export const HurricaneIcon = observer(function HurricaneIcon({ dragging }: IHurr
   const opacity = hurrStrengthToOpacity(hurricane.strength);
 
   const { hurricaneImage, mapZoom, setupMode } = stores.ui;
-  const dimmed = !!setupMode && setupMode !== "stormLocation";
+  const dimmed = !!setupMode && !["stormLocation", "stormCategory"].includes(setupMode);
   const draggable = setupMode === "stormLocation";
 
   const getLabel = () => {

--- a/src/components/top-bar/copyright.tsx
+++ b/src/components/top-bar/copyright.tsx
@@ -4,14 +4,14 @@ export class Copyright extends React.Component {
   public render() {
     return (
       <p style={{ fontSize: "0.8em" }}>
-        <b>Copyright © {(new Date()).getFullYear()}</b> <a href="http://concord.org" target="_blank">The Concord
-        Consortium</a>.
+        <b>Copyright © {(new Date()).getFullYear()}</b> <a href="https://concord.org" target="_blank"
+        rel="noopener noreferrer">The Concord Consortium</a>.
         All rights reserved. This resource is licensed under
-        the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">
+        the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener noreferrer">
         Creative Commons Attribution-NonCommercial 4.0 International License (CC BY-NC 4.0)</a>.
-        Please provide attribution to the Concord Consortium and the URL <a href="https://concord.org" target="_blank">
-        https://concord.org</a>. For full licensing details, see <a href="https://concord.org/licensing/"
-        target="_blank">concord.org/licensing</a>.
+        Please provide attribution to the Concord Consortium and the URL <a href="https://concord.org" target="_blank"
+        rel="noopener noreferrer">https://concord.org</a>. For full licensing details, see <a
+        href="https://concord.org/licensing/" target="_blank" rel="noopener noreferrer">concord.org/licensing</a>.
       </p>
     );
   }

--- a/src/components/top-bar/copyright.tsx
+++ b/src/components/top-bar/copyright.tsx
@@ -6,13 +6,12 @@ export class Copyright extends React.Component {
       <p style={{ fontSize: "0.8em" }}>
         <b>Copyright © {(new Date()).getFullYear()}</b> <a href="http://concord.org" target="_blank">The Concord
         Consortium</a>.
-        All rights reserved. The software is licensed under
-        the <a href="https://github.com/concord-consortium/tectonic-explorer/blob/master/LICENSE"
-               target="_blank">MIT</a> license.
-        The content is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">Creative
-        Commons Attribution 4.0 International License</a>.
-        Please provide attribution to the Concord Consortium and the URL <a href="http://concord.org"
-                                                                            target="_blank">http://concord.org</a>.
+        All rights reserved. This resource is licensed under
+        the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">
+        Creative Commons Attribution-NonCommercial 4.0 International License (CC BY-NC 4.0)</a>.
+        Please provide attribution to the Concord Consortium and the URL <a href="https://concord.org" target="_blank">
+        https://concord.org</a>. For full licensing details, see <a href="https://concord.org/licensing/"
+        target="_blank">concord.org/licensing</a>.
       </p>
     );
   }


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/HURR-32

This PR updates the license of the hurricane/storm explorer sim.

Additionally, it stops dimming the hurricane marker when adjusting the starting storm category.