### PR TITLE
Set webpack publicPath to 'auto' so assets load on released site (HURR-41)

### DIFF
--- a/cypress/e2e/integration/basic.cy.js
+++ b/cypress/e2e/integration/basic.cy.js
@@ -82,7 +82,7 @@ context("Test the Hurricane Model app", () => {
         cy.get('.sst-key--checkbox--__hurr-v1__ input[type="checkbox"]')
           .click()
           .then(() => {
-            cy.get('[src="91071a502fa66c0cde3e.png"]').should("be.visible");
+            cy.get('[src$="91071a502fa66c0cde3e.png"]').should("be.visible");
           });
       });
 

--- a/cypress/e2e/integration/basic.cy.js
+++ b/cypress/e2e/integration/basic.cy.js
@@ -82,7 +82,12 @@ context("Test the Hurricane Model app", () => {
         cy.get('.sst-key--checkbox--__hurr-v1__ input[type="checkbox"]')
           .click()
           .then(() => {
-            cy.get('[src$="91071a502fa66c0cde3e.png"]').should("be.visible");
+            cy.window().then((win) => {
+              const { ui, simulation } = win.stores;
+              expect(ui.sstOverlay.accessibleSSTScale).to.eq(true);
+              const expectedUrl = ui.sstOverlay.getVisibleSeaSurfaceTempImgUrl(simulation.season);
+              cy.get(`img[src="${expectedUrl}"]`).should("be.visible");
+            });
           });
       });
 

--- a/src/models/sst-overlay.ts
+++ b/src/models/sst-overlay.ts
@@ -206,8 +206,11 @@ export class SSTOverlayModel {
     this.targetUrl = url;
     fetch(url).then(response => {
       // Only continue if the response url is the same file as the last requested url, which prevents older but slower
-      // fetches from overriding a faster but newer one.
-      if (!response.ok || (new URL(response.url)).pathname.split("/").pop() !== this.targetUrl) return;
+      // fetches from overriding a faster but newer one. Compare filenames only: with publicPath 'auto' the asset
+      // urls are absolute (and may contain un-normalized segments like "assets/../"), while response.url is
+      // normalized. The content-hashed filenames are unique, so this is sufficient.
+      const targetFilename = this.targetUrl?.split("/").pop();
+      if (!response.ok || (new URL(response.url)).pathname.split("/").pop() !== targetFilename) return;
 
       response.arrayBuffer().then(buffer => {
         new PNG().parse(Buffer.from(buffer), (err, png) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = (env, argv) => {
     mode: 'development',
     output: {
       filename: 'assets/index.[contenthash].js',
-      publicPath: ''
+      publicPath: 'auto'
     },
     performance: { hints: false },
     module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = (env, argv) => {
     context: __dirname, // to automatically find tsconfig.json
     devtool: 'source-map',
     entry: './src/index.tsx',
-    mode: 'development',
+    mode: devMode ? 'development' : 'production',
     output: {
       filename: 'assets/index.[contenthash].js',
       publicPath: 'auto'


### PR DESCRIPTION
Fixes [HURR-41](https://concord-consortium.atlassian.net/browse/HURR-41): the v1.8.0 release at https://hurricane.concord.org/ 404s on four runtime-loaded images (three PNGs and one SVG), one of which is a sea-surface-temperature image the simulation decodes.

## Root cause

The webpack 4→5 migration set `output.publicPath: ''`, so the bundle emits bare `"<hash>.png"` asset URLs that the browser resolves against the *page* URL. Branch deploys work because `index.html` sits in the build directory, but the released site serves a root-level `index.html` (the `index-top.html` copy) whose relative image URLs resolve to the site root, where the files don't exist.

Earlier releases only worked by accident: webpack 4's `file-loader` used stable content-based md5 filenames, and stale copies of those files still exist at the site root from an old full-site deploy. Webpack 5 asset modules use a different hash scheme, so the filenames stopped matching.

A second regression from the same migration: SVGs referenced from SCSS were previously inlined as data URIs by `url-loader`, but `asset/resource` emits them at the build root while the CSS resolves the URL relative to `assets/` — that SVG 404s on branch deploys too.

## Fix

`publicPath: 'auto'` makes webpack compute the base URL at runtime from the script's own `src` (stripping the `assets/` directory), and makes mini-css-extract emit relative `url(../<hash>.svg)` references. This is correct for both the released layout and branch deploys, since URLs derive from the script location rather than the page location.

## Verification

Built production with `DEPLOY_PATH=version/v1.8.1/`, replicated the S3 release layout locally (root `index.html` copied from `index-top.html` plus a `version/v1.8.1/` directory), and loaded `?mode=storm` in a browser: all four previously-failing assets returned 200 with zero console errors, including the SCSS-referenced SVG that also 404s on the current master branch deploy.

## Release steps after merge

1. Tag v1.8.1 so CI deploys it to `version/v1.8.1/`.
2. Re-run the Release workflow with `v1.8.1`.


[HURR-41]: https://concord-consortium.atlassian.net/browse/HURR-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ