### PR TITLE
feat: switch S3 deployment to OIDC authentication (DEV-163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
       - build_test
     #   - cypress
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -69,13 +73,15 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/hurricane-model
+          aws-region: us-east-1
       - uses: concord-consortium/s3-deploy-action@v1
         with:
           bucket: models-resources
           prefix: hurricane-model
           build: env NODE_OPTIONS=--openssl-legacy-provider npm run build
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           deployRunUrl: https://models-resources.concord.org/hurricane-model/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release ${{ github.event.inputs.version }}
 on:
   workflow_dispatch:
     inputs:
@@ -13,12 +14,14 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/hurricane-model
+          aws-region: us-east-1
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/${{ env.DEST_FILE }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Hurricane Model
 
+## Deployment
+
+S3 deployment is handled by GitHub Actions using OIDC for AWS authentication. See
+[deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md)
+for how the AWS side is set up, and [doc/deploy.md](doc/deploy.md) for how deploys work
+in this repo.
+
 ## Logged Events
 
 See [LOGGED-EVENTS.md](LOGGED-EVENTS.md) for a complete reference of all logged events, their parameters, and trigger conditions.

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -1,0 +1,19 @@
+# Deployment
+
+S3 deployment is handled by GitHub Actions. Pushes are deployed to
+`models-resources/hurricane-model/` by the `s3-deploy` job in
+[`ci.yml`](../.github/workflows/ci.yml), and a released version is promoted to the
+top-level `index.html` by [`release.yml`](../.github/workflows/release.yml) via
+`workflow_dispatch`.
+
+## AWS Access
+
+The GitHub actions in this project are allowed to update files in S3 using OIDC. An
+IAM role has been created in AWS with a trust policy that allows GitHub actions in
+this specific repository to assume this IAM role. The IAM role has a `RepoName` tag
+and a managed policy that uses this tag to give the role's users permission to update
+files in `models-resources/[RepoName]`.
+
+See
+[deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md)
+for how the AWS side is set up.


### PR DESCRIPTION
[DEV-163](https://concord-consortium.atlassian.net/browse/DEV-163)

Migrates hurricane-model's S3 deploy workflows off static AWS access keys to OIDC role assumption, per [DEV-163] and the [ocean-explorer reference PR](https://github.com/concord-consortium/ocean-explorer/pull/1).

**Changes:**

- **`ci.yml` (`s3-deploy`)** — added `id-token: write` / `contents: read` / `deployments: write` permissions, added `configure-aws-credentials@v6`, removed the `awsAccessKeyId`/`awsSecretAccessKey` inputs.
- **`release.yml`** — added `run-name`, `id-token: write` (plain `aws s3 cp`, so no checkout/deployment perms), added `configure-aws-credentials@v6` (region via `aws-region`), removed the `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_DEFAULT_REGION` env.
- **docs** — added `doc/deploy.md` and a README deployment section.

[DEV-163]: https://concord-consortium.atlassian.net/browse/DEV-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-163]: https://concord-consortium.atlassian.net/browse/DEV-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ